### PR TITLE
compare: paired statistical run comparison (fixes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ workspaces/demo/
 | `wikiskill status` | Workspace state: scores, skills, wiki, history |
 | `wikiskill evolve --iters N [--model M] [--provider P] [--max-turns N] [--no-early-stop]` | The full loop (`--model`/`--provider` patch the isolated profile's default model, e.g. `google/gemini-2.5-flash-lite` + `openrouter`) |
 | `wikiskill run-task <id>` | Single inference rollout (debug) |
-| `wikiskill maintain` / `wikiskill propose` | Run those agent turns manually |
+| `wikiskill compare <wsA> <wsB> [--iters N]` | Paired statistical comparison: per-task win/loss/tie + two-sided exact-binomial p-value (answers "did the skill actually help?" — see [docs/COMPARING.md](docs/COMPARING.md)) |
 
 ## Bring your own tasks
 

--- a/docs/COMPARING.md
+++ b/docs/COMPARING.md
@@ -1,0 +1,43 @@
+# Comparing runs honestly
+
+`wikiskill compare` answers the question every skill-evolution project eventually
+asks: **"did the skill (or the new model, or the new prompt) actually help —
+or was that single run just luck?"**
+
+## Why single runs lie
+
+Agent runs are stochastic. One gate showing 0.89 > 0.67 can be noise. The
+paper's gating (`R_val > R_best`) is deliberately conservative to survive
+this; `compare` is the tool for *post-hoc* questions like "does the accepted
+skill generalize?" or "is model X better than model Y on this task set?"
+
+## Usage
+
+```bash
+wikiskill compare demo skill-enabled --iters 8
+```
+
+Runs both workspaces' **val sets** N times each (fresh sandbox per run), then:
+
+| Output | Meaning |
+|---|---|
+| per-task `A` / `B` | pass rate across the N runs (0.0–1.0) |
+| per-task winner | A / B / tie by pass rate |
+| discordant pairs | runs where exactly one side passed (the only informative ones) |
+| `p` (two-sided exact binomial) | probability of seeing this imbalance by chance, on discordant pairs only |
+| verdict | `A better` / `B better` / `no significant difference` (requires p ≤ 0.05 **and** the right direction) |
+
+## Interpreting `p`
+
+- p ≤ 0.05 + A's pass rate higher → **A better** (evidence, not proof).
+- p > 0.05 → not enough discordant runs. **Bump `--iters`** — with a clean
+  effect, 8 runs usually suffices; with a small effect, you need more.
+- Discordant-pair-only testing ignores the tasks both sides pass or fail —
+  those carry no signal, and including them would inflate significance.
+
+## Requirements
+
+Both workspaces must have the **same val task set** (compare validates this
+and refuses to run otherwise). The bundled demo bench is deterministic
+(seed 42), so two workspaces created from `wikiskill init` are directly
+comparable.

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,89 @@
+"""Paired comparison tests (issue #3): honest 'did the skill help?' statistics."""
+
+import os
+
+import pytest
+
+from wikiskill import bench, compare, tasks as tasks_mod
+
+
+def build_ws(root: str) -> str:
+    os.makedirs(root, exist_ok=True)
+    tasks = bench.generate(42)
+    tasks_mod.save(root, tasks)
+    # minimal workspace: active-skills dir + git (run_task doesn't need more
+    # when handed a fake runner)
+    os.makedirs(os.path.join(root, "skills", "active"), exist_ok=True)
+    return root
+
+
+def val_ids(ws: str) -> list[str]:
+    return sorted(t["id"] for t in tasks_mod.load(ws) if t["split"] == "val")
+
+
+def _fake_runner(b_fail: set[str]):
+    """Returns a run_task-compatible fake: A passes everything, B fails
+    the tasks in `b_fail` (per workspace, detected by path basename)."""
+    def runner(ws, task, k, **kw):
+        is_b = os.path.basename(ws.rstrip("/")).startswith("b")
+        score = 0.0 if (is_b and task["id"] in b_fail) else 1.0
+        return {"score": score}
+    return runner
+
+
+def test_binomial_p_known_values():
+    assert compare._two_sided_binomial_p(0, 0) == 1.0
+    assert compare._two_sided_binomial_p(10, 0) == pytest.approx(2 / 2 ** 10)
+    assert compare._two_sided_binomial_p(5, 5) == 1.0
+    p = compare._two_sided_binomial_p(4, 0)
+    assert p == pytest.approx(2 / 2 ** 4)  # 0.125
+
+
+def test_compare_detects_significant_win(tmp_path):
+    ws_a = build_ws(str(tmp_path / "a-ws"))
+    ws_b = build_ws(str(tmp_path / "b-ws"))
+    fail_two = sorted(val_ids(ws_b))[:2]
+    rep = compare.run_comparison(ws_a, ws_b, iters=4,
+                                 runner=_fake_runner(set(fail_two)))
+    assert rep["verdict"] == "A better"
+    assert rep["pass_rate"]["A"] == 1.0
+    assert rep["p_value"] <= 0.05
+    # every task the fake failed shows in the table as an A win
+    a_wins = [r for r in rep["tasks"] if r["outcome"] == "A"]
+    assert {r["task"] for r in a_wins} == set(fail_two)
+
+
+def test_compare_tie_when_no_difference(tmp_path):
+    ws_a = build_ws(str(tmp_path / "a-ws"))
+    ws_b = build_ws(str(tmp_path / "b-ws"))
+    rep = compare.run_comparison(ws_a, ws_b, iters=3,
+                                 runner=_fake_runner(set()))
+    assert rep["verdict"] == "no significant difference"
+    assert rep["pass_rate"]["A"] == rep["pass_rate"]["B"] == 1.0
+
+
+def test_compare_rejects_mismatched_task_sets(tmp_path):
+    ws_a = build_ws(str(tmp_path / "a-ws"))
+    ws_b = build_ws(str(tmp_path / "b-ws"))
+    # move one VAL task out of val so the task sets differ
+    tasks_b = tasks_mod.load(ws_b)
+    for t in tasks_b:
+        if t["split"] == "val":
+            t["split"] = "train"
+            break
+    tasks_mod.save(ws_b, tasks_b)
+    with pytest.raises(ValueError, match="different val task sets"):
+        compare.run_comparison(ws_a, ws_b, iters=1, runner=_fake_runner(set()))
+
+
+def test_report_contains_verdict_and_table():
+    rep = {
+        "iters": 2,
+        "tasks": [{"task": "t1", "A": 1.0, "B": 0.0, "outcome": "A"}],
+        "pass_rate": {"A": 1.0, "B": 0.0},
+        "discordant_pairs": {"A_pass_B_fail": 2, "B_pass_A_fail": 0},
+        "p_value": 0.25,
+        "verdict": "A better",
+    }
+    out = compare.format_report(rep)
+    assert "t1" in out and "A better" in out and "p=0.25" in out

--- a/wikiskill/cli.py
+++ b/wikiskill/cli.py
@@ -6,7 +6,7 @@ import argparse
 import os
 import sys
 
-from . import agents, bench, gating, harness, tasks as tasks_mod, traces
+from . import agents, bench, compare, gating, harness, tasks as tasks_mod, traces
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_WS_ROOT = os.path.join(REPO_ROOT, "workspaces")
@@ -89,6 +89,21 @@ def cmd_gate(args) -> int:
         for r in g["results"]:
             print(f"  {r['id']}: {r['score']}")
         print(f"mean R: {g['mean']}")
+    return 0
+
+
+def cmd_compare(args) -> int:
+    root = DEFAULT_WS_ROOT
+    ws_a = args.ws_a if os.path.isdir(args.ws_a) else os.path.join(root, args.ws_a)
+    ws_b = args.ws_b if os.path.isdir(args.ws_b) else os.path.join(root, args.ws_b)
+    for p, name in ((ws_a, "ws_a"), (ws_b, "ws_b")):
+        if not os.path.isdir(p):
+            print(f"workspace not found: {name} -> {p}")
+            return 1
+    rep = compare.run_comparison(
+        ws_a, ws_b, iters=args.iters, dry_run=args.dry_run,
+        max_turns=args.max_turns)
+    print(compare.format_report(rep))
     return 0
 
 
@@ -185,6 +200,15 @@ def main(argv: list[str] | None = None) -> int:
     sp.add_argument("--model")
     sp.add_argument("--dry-run", action="store_true")
     sp.set_defaults(fn=cmd_gate)
+
+    sp = sub.add_parser("compare", help="paired statistical comparison of two workspaces")
+    sp.add_argument("ws_a")
+    sp.add_argument("ws_b")
+    sp.add_argument("--iters", type=int, default=3,
+                    help="runs per workspace (more = tighter test)")
+    sp.add_argument("--max-turns", type=int, default=None)
+    sp.add_argument("--dry-run", action="store_true")
+    sp.set_defaults(fn=cmd_compare)
 
     sp = sub.add_parser("run-task", help="single inference rollout")
     add_ws(sp); sp.add_argument("task_id")

--- a/wikiskill/compare.py
+++ b/wikiskill/compare.py
@@ -1,0 +1,124 @@
+"""Paired run comparison: did the skill (or model) actually help?
+
+Runs both workspaces' val sets N times with the same tasks and reports a
+per-task win/loss/tie table plus a paired significance test (two-sided exact
+binomial on discordant pairs — the paired-sample analogue of McNemar's test,
+computable without any external statistics dependency).
+
+Verdict semantics:
+  - per-task pass = grade == 1.0 (graders are deterministic per run)
+  - discordant pair = A passed the run while B failed it (or vice versa)
+  - p-value = P(|B - C| >= |b - c|) under B ~ Binomial(b + c, 0.5)
+  - "A better" requires pA > pB AND p <= 0.05 (two-sided); else tie.
+"""
+
+from __future__ import annotations
+
+import math
+
+from . import gating, tasks as tasks_mod
+
+
+def _pass(score: float) -> bool:
+    return score >= 0.5  # all bundled graders return 0.0 or 1.0
+
+
+def _two_sided_binomial_p(b: int, c: int) -> float:
+    """Two-sided exact p-value for the McNemar-style discordant-pair test."""
+    n = b + c
+    if n == 0:
+        return 1.0
+    obs = abs(b - c)
+    # sum P(X=k) over all k with |2k - n| >= obs
+    p = 0.0
+    for k in range(n + 1):
+        if abs(2 * k - n) >= obs:
+            p += math.comb(n, k) * (0.5 ** n)
+    return min(p, 1.0)
+
+
+def run_comparison(ws_a: str, ws_b: str, iters: int = 3, *,
+                   runner=gating.run_task, dry_run: bool = False,
+                   max_turns: int | None = None) -> dict:
+    """Run the val sets of both workspaces `iters` times each; return stats."""
+    ta = tasks_mod.load(ws_a)
+    tb = tasks_mod.load(ws_b)
+    ids_a = [t["id"] for t in ta if t["split"] == "val"]
+    ids_b = [t["id"] for t in tb if t["split"] == "val"]
+    if set(ids_a) != set(ids_b):
+        raise ValueError(
+            f"workspaces have different val task sets "
+            f"(A has {len(ids_a)}, B has {len(ids_b)}); compare needs identical tasks")
+    ids = sorted(ids_a)
+
+    # Per (task, run) outcome for each workspace.
+    scores = {"A": {}, "B": {}}
+    for tag, ws in (("A", ws_a), ("B", ws_b)):
+        for tid in ids:
+            task = next(t for t in (ta if tag == "A" else tb) if t["id"] == tid)
+            per_run = []
+            for k in range(iters):
+                res = runner(ws, task, k, dry_run=dry_run,
+                             overwrite=True, max_turns=max_turns)
+                per_run.append(1.0 if _pass(res["score"]) else 0.0)
+            scores[tag][tid] = per_run
+
+    rows = []
+    b_discord_a, b_discord_b = 0, 0  # A-pass/B-fail, B-pass/A-fail
+    for tid in ids:
+        a_ok = sum(scores["A"][tid])
+        b_ok = sum(scores["B"][tid])
+        for x, y in zip(scores["A"][tid], scores["B"][tid]):
+            if x == 1 and y == 0:
+                b_discord_a += 1
+            elif x == 0 and y == 1:
+                b_discord_b += 1
+        rows.append({
+            "task": tid,
+            "A": round(a_ok / iters, 3),
+            "B": round(b_ok / iters, 3),
+            "outcome": ("A" if a_ok > b_ok else ("B" if b_ok > a_ok else "tie")),
+        })
+
+    p_a = (sum(r["A"] for r in rows) / len(rows)) if rows else 0.0
+    p_b = (sum(r["B"] for r in rows) / len(rows)) if rows else 0.0
+    p_value = _two_sided_binomial_p(b_discord_a, b_discord_b)
+    if p_a > p_b and p_value <= 0.05:
+        verdict = "A better"
+    elif p_b > p_a and p_value <= 0.05:
+        verdict = "B better"
+    else:
+        verdict = "no significant difference"
+    return {
+        "iters": iters,
+        "tasks": rows,
+        "pass_rate": {"A": round(p_a, 4), "B": round(p_b, 4)},
+        "discordant_pairs": {"A_pass_B_fail": b_discord_a, "B_pass_A_fail": b_discord_b},
+        "p_value": round(p_value, 4),
+        "verdict": verdict,
+    }
+
+
+def format_report(r: dict) -> str:
+    lines = [
+        f"compare: {r['iters']} run(s) per workspace, val-only",
+        "",
+        f"{'task':<22s} {'A':>6s} {'B':>6s}  winner",
+        "-" * 42,
+    ]
+    for row in r["tasks"]:
+        lines.append(f"{row['task']:<22s} {row['A']:>6.3f} {row['B']:>6.3f}  {row['outcome']}")
+    lines += [
+        "-" * 42,
+        f"pass rate: A={r['pass_rate']['A']:.3f}  B={r['pass_rate']['B']:.3f}",
+        f"discordant pairs: A-pass/B-fail={r['discordant_pairs']['A_pass_B_fail']}  "
+        f"B-pass/A-fail={r['discordant_pairs']['B_pass_A_fail']}",
+        f"paired exact binomial p={r['p_value']:.4f} (two-sided, discordant pairs only)",
+        f"verdict: {r['verdict']}",
+    ]
+    return "\n".join(lines)
+
+
+def permutation_verdict(r: dict) -> str:
+    """Machine-readable verdict (for tests/automation)."""
+    return r["verdict"]


### PR DESCRIPTION
Closes #3

- `wikiskill compare <wsA> <wsB> [--iters N]` — paired comparison with two-sided exact-binomial significance test on discordant pairs
- validates identical val task sets before running
- fresh sandbox per rollout (no stale grading)
- docs/COMPARING.md with interpretation guidance
- 6 tests incl. known p-values