### PR TITLE
transfer: cross-workspace skill export/import (fixes #1)

### DIFF
--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -1,0 +1,63 @@
+"""Skill transfer tests (issue #1): cross-model/workspace skill export/import."""
+
+import os
+import subprocess
+
+import pytest
+
+from wikiskill import transfer
+
+
+def make_ws(root: str, with_skill: str | None = None) -> str:
+    d = os.path.join(root, "skills", "active")
+    os.makedirs(d, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=d, check=False)
+    if with_skill:
+        s = os.path.join(d, with_skill)
+        os.makedirs(s, exist_ok=True)
+        with open(os.path.join(s, "SKILL.md"), "w") as f:
+            f.write(f"---\nname: {with_skill}\n---\nbody")
+        subprocess.run(["git", "add", "-A"], cwd=d, check=False)
+        subprocess.run(["git", "-c", "user.email=wikiskill@local",
+                        "-c", "user.name=wikiskill", "commit", "-q",
+                        "-m", f"add {with_skill}"], cwd=d, check=False)
+    return root
+
+
+def test_transfer_copies_skills(tmp_path):
+    src = make_ws(str(tmp_path / "src"), with_skill="keep-calm")
+    dst = make_ws(str(tmp_path / "dst"))
+    m = transfer.transfer_skills(src, dst)
+    assert m["transferred"] == ["keep-calm"]
+    assert os.path.isfile(os.path.join(dst, "skills", "active", "keep-calm", "SKILL.md"))
+    # source untouched
+    assert transfer.active_skills(src) == ["keep-calm"]
+    # destination git history records the transfer (rollback available)
+    log = subprocess.run(["git", "-C", os.path.join(dst, "skills", "active"),
+                          "log", "--oneline"], capture_output=True, text=True).stdout
+    assert "transfer from src" in log
+
+
+def test_transfer_skips_duplicate_without_force(tmp_path):
+    src = make_ws(str(tmp_path / "src"), with_skill="same-skill")
+    dst = make_ws(str(tmp_path / "dst"), with_skill="same-skill")
+    m = transfer.transfer_skills(src, dst)
+    assert m["transferred"] == [] and m["skipped"] == ["same-skill"]
+    m2 = transfer.transfer_skills(src, dst, force=True)
+    assert m2["transferred"] == ["same-skill"]
+
+
+def test_transfer_requires_active_skills(tmp_path):
+    src = make_ws(str(tmp_path / "src"))
+    dst = make_ws(str(tmp_path / "dst"))
+    with pytest.raises(ValueError, match="no active skills"):
+        transfer.transfer_skills(src, dst)
+
+
+def test_transfer_skips_dirs_without_skillmd(tmp_path):
+    src = make_ws(str(tmp_path / "src"), with_skill="good")
+    os.makedirs(os.path.join(src, "skills", "active", "no-skill-md"), exist_ok=True)
+    dst = make_ws(str(tmp_path / "dst"))
+    m = transfer.transfer_skills(src, dst)
+    assert m["transferred"] == ["good"]
+    assert "no-skill-md" in m["skipped"]

--- a/wikiskill/cli.py
+++ b/wikiskill/cli.py
@@ -6,7 +6,7 @@ import argparse
 import os
 import sys
 
-from . import agents, bench, compare, gating, harness, tasks as tasks_mod, traces
+from . import agents, bench, compare, gating, harness, tasks as tasks_mod, traces, transfer
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_WS_ROOT = os.path.join(REPO_ROOT, "workspaces")
@@ -104,6 +104,19 @@ def cmd_compare(args) -> int:
         ws_a, ws_b, iters=args.iters, dry_run=args.dry_run,
         max_turns=args.max_turns)
     print(compare.format_report(rep))
+    return 0
+
+
+def cmd_transfer(args) -> int:
+    root = DEFAULT_WS_ROOT
+    src = args.src if os.path.isdir(args.src) else os.path.join(root, args.src)
+    dst = args.dst if os.path.isdir(args.dst) else os.path.join(root, args.dst)
+    for p, name in ((src, "src"), (dst, "dst")):
+        if not os.path.isdir(p):
+            print(f"workspace not found: {name} -> {p}")
+            return 1
+    m = transfer.transfer_skills(src, dst, force=args.force)
+    print(transfer.format_report(m))
     return 0
 
 
@@ -209,6 +222,12 @@ def main(argv: list[str] | None = None) -> int:
     sp.add_argument("--max-turns", type=int, default=None)
     sp.add_argument("--dry-run", action="store_true")
     sp.set_defaults(fn=cmd_compare)
+
+    sp = sub.add_parser("transfer", help="copy one workspace's active skills into another")
+    sp.add_argument("src")
+    sp.add_argument("dst")
+    sp.add_argument("--force", action="store_true", help="overwrite same-named skills")
+    sp.set_defaults(fn=cmd_transfer)
 
     sp = sub.add_parser("run-task", help="single inference rollout")
     add_ws(sp); sp.add_argument("task_id")

--- a/wikiskill/transfer.py
+++ b/wikiskill/transfer.py
@@ -1,0 +1,79 @@
+"""Skill transfer across workspaces/models (issue #1).
+
+The paper shows evolved skills transfer across models and model families.
+`transfer` exports the active skill set from one workspace and installs it
+into another workspace's active set, where the destination's own model can be
+gated against it (`wikiskill gate` / `evolve`). The destination's previous
+skill state is preserved in its own git history, so a rejected transfer rolls
+back exactly like any other rejected proposal.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+
+def active_skills(ws: str) -> list[str]:
+    d = os.path.join(ws, "skills", "active")
+    if not os.path.isdir(d):
+        return []
+    return sorted(n for n in os.listdir(d)
+                  if os.path.isdir(os.path.join(d, n)) and not n.startswith("."))
+
+
+def transfer_skills(src: str, dst: str, *, force: bool = False) -> dict:
+    """Copy src's active skills into dst's active set. Returns a manifest."""
+    src_dir = os.path.join(src, "skills", "active")
+    dst_dir = os.path.join(dst, "skills", "active")
+    if not os.path.isdir(src_dir):
+        raise ValueError(f"no active skills in source workspace: {src}")
+    if not os.path.isdir(dst_dir):
+        raise ValueError(f"no active skills in destination workspace: {dst}")
+    if not active_skills(src):
+        raise ValueError(f"no active skills in source workspace: {src}")
+    # destination must have its own git history so transfers can be rolled back
+    if not os.path.isdir(os.path.join(dst_dir, ".git")):
+        subprocess.run(["git", "init", "-q"], cwd=dst_dir, check=False)
+
+    names = active_skills(src)
+    transferred, skipped = [], []
+    for n in names:
+        s = os.path.join(src_dir, n)
+        if not os.path.isfile(os.path.join(s, "SKILL.md")):
+            skipped.append(n)
+            continue
+        t = os.path.join(dst_dir, n)
+        if os.path.exists(t) and not force:
+            skipped.append(n)
+            continue
+        if os.path.exists(t):
+            shutil.rmtree(t)
+        shutil.copytree(s, t)
+        transferred.append(n)
+    if transferred:
+        subprocess.run(["git", "-c", "user.email=wikiskill@local",
+                        "-c", "user.name=wikiskill", "add", "-A"],
+                       cwd=dst_dir, check=False)
+        subprocess.run(["git", "-c", "user.email=wikiskill@local",
+                        "-c", "user.name=wikiskill", "commit", "-q",
+                        "-m", f"transfer from {os.path.basename(src)}: "
+                              f"{', '.join(transferred)}"],
+                       cwd=dst_dir, check=False)
+    return {"transferred": transferred, "skipped": skipped,
+            "source": os.path.basename(src), "destination": os.path.basename(dst)}
+
+
+def format_report(m: dict) -> str:
+    lines = [f"transfer {m['source']} → {m['destination']}"]
+    if m["transferred"]:
+        lines.append("  installed: " + ", ".join(m["transferred"]))
+    if m["skipped"]:
+        lines.append("  skipped:   " + ", ".join(m["skipped"]) +
+                     " (no SKILL.md or already present; use --force to overwrite)")
+    if not m["transferred"]:
+        lines.append("  nothing to transfer")
+    lines.append("  next: `wikiskill gate --iter 0` in the destination to test "
+                 "the transferred skills against its own model")
+    return "\n".join(lines)


### PR DESCRIPTION
Closes #1 (implementation half — the cross-model demo run is the follow-up)

- `wikiskill transfer <src> <dst> [--force]` — installs the source workspace's active skill set into the destination's, so the destination's own model can be gated against foreign-evolved skills (the paper's transfer result)
- every transfer is a git commit in the destination's skills/active — rejected transfers roll back exactly like rejected proposals
- 4 tests