### PR TITLE
docs site: mkdocs-material GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,40 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -q mkdocs mkdocs-material
+      - run: mkdocs build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+site/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Compile agent experience into a persistent wiki — and let skills evolve themselves.**
 
+> 📚 **Docs site**: [ashutoshsinghpr7.github.io/wikiskill-hermes](https://ashutoshsinghpr7.github.io/wikiskill-hermes) · **arXiv**: [2608.27454](https://arxiv.org/abs/2608.27454)
+
 A faithful, production-minded implementation of **[WikiSkill: Compiling Agent Experience into Persistent Knowledge for Skill Evolution](https://arxiv.org/abs/2608.27454)** (arXiv:2608.27454, Google Research), built natively on **[Hermes Agent](https://hermes-agent.nousresearch.com/docs)** — your own agent becomes both the *student* and the *teacher*.
 
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org)

--- a/docs/CRON.md
+++ b/docs/CRON.md
@@ -1,0 +1,46 @@
+# Overnight evolution (cron)
+
+Evolution runs are **slow** (a full iteration is ~1–2 hours on a free-tier
+small model) and **cheap** (~$0.09/iteration). That's the ideal overnight
+workload: the machine works while you sleep, and the morning report tells
+you whether the wiki grew and whether any proposal was accepted.
+
+## The built-in job
+
+This repo ships with a hermes cron job, `wikiskill-overnight-evolution`,
+which every night at 01:00 (local time):
+
+1. runs `wikiskill evolve nightly --iters 1 --max-turns 8
+   --model google/gemini-2.5-flash-lite --provider openrouter` on a
+   dedicated `workspaces/nightly/` (its own isolated profile — your real
+   Hermes setup is never touched),
+2. waits for it,
+3. reports: baseline R, wiki growth, proposal, and the gate verdict —
+   honestly, including rate-limit or launch failures if they happen.
+
+Manage it from Hermes: `cronjob(action='list')` / `pause` / `run`.
+
+## Setting it up yourself (non-Hermes schedulers)
+
+```bash
+# macOS: crontab -e
+0 1 * * * cd /path/to/wikiskill-hermes && \
+  wikiskill evolve nightly --iters 1 --max-turns 8 \
+    --model google/gemini-2.5-flash-lite --provider openrouter \
+    >> workspaces/nightly/cron.log 2>&1
+```
+
+## What to check in the morning
+
+- `wikiskill status nightly` → baseline / r_best / iteration history
+- `workspaces/nightly/wiki/log.md` → per-iteration proposal + verdict
+- `workspaces/nightly/wiki/patterns/` → what the maintainer distilled
+- the gate verdict: `ACCEPT` means the skill beat the previous best
+  (`R_val > R_best`) and is now the workspace's active skill set.
+
+## Guard rails
+
+- The cron prompt refuses to run if an evolve is already in flight
+  (concurrent runs would corrupt `runs/state.json`).
+- Launch failures (HTTP 400, rate limits) are detected and reported — a
+  dead run scores 0.0 on fresh sandboxes, never phantom grades.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,46 @@
+# WikiSkill for Hermes
+
+**Compile agent experience into a persistent wiki — and let skills evolve themselves.**
+
+WikiSkill is a Google Research framework (arXiv:2608.27454) that co-evolves
+agent skills with a persistent knowledge base. This repository is a faithful
+implementation for **Hermes Agent**, with a live, documented run log on real
+models.
+
+## The loop
+
+```
+raw experience ──► persistent wiki ──► skill proposals ──► gated rollout
+(session traces)   (pattern pages)      (SKILL.md)         R_val > R_best ?
+```
+
+1. **Raw layer** — agents execute tasks; full transcripts are captured.
+2. **Wiki maintainer** — distills low-scoring traces into pattern pages in a
+   persistent wiki (never rolled back — knowledge accumulates).
+3. **Skill proposer** — proposes new skills from wiki patterns + trace
+   evidence, with full rejected proposals kept visible (anti-repetition).
+4. **Gating** — the candidate skill is rolled out on held-out tasks; accepted
+   iff `R_val > R_best`, otherwise git-rolled-back. The wiki is always kept.
+
+## Why this repo
+
+- **The full loop, live** — every phase runs on a real agent (Hermes) with
+  isolated per-workspace profiles; see the [Run Log](RUNS.md).
+- **Small-model story proven** — a free-tier model failed at baseline (0.67),
+  and gating caught a *harmful* proposed skill live (R dropped to 0.44) and
+  rolled it back.
+- **Honest by construction** — fresh sandboxes per rollout (no stale grading),
+  zero-tool-call launch-failure detection, paired statistical comparison
+  ([Comparing runs](COMPARING.md)), and a documented list of bugs found and
+  fixed during development.
+
+## Quickstart
+
+```bash
+pip install -e .
+wikiskill init demo
+wikiskill evolve demo --iters 1 --model google/gemini-2.5-flash-lite --provider openrouter
+wikiskill status demo
+```
+
+Runs cost ≈ $0.09/iteration on free-tier models. See the [full README](https://github.com/ashutoshsinghpr7/wikiskill-hermes#readme) for the complete guide, CLI reference, and design decisions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,40 @@
+site_name: WikiSkill for Hermes
+site_description: Self-evolving agent skills via a persistent knowledge wiki — a faithful implementation of arXiv:2608.27454 for Hermes Agent.
+site_url: https://ashutoshsinghpr7.github.io/wikiskill-hermes/
+repo_url: https://github.com/ashutoshsinghpr7/wikiskill-hermes
+edit_uri: blob/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: indigo
+      accent: cyan
+      toggle:
+        icon: material/weather-night
+        name: Switch to light mode
+    - scheme: default
+      primary: indigo
+      accent: cyan
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to dark mode
+  features:
+    - navigation.instant
+    - navigation.top
+    - content.code.copy
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Run Log: RUNS.md
+  - Comparing runs: COMPARING.md
+  - Overnight evolution: CRON.md
+  - GitHub: https://github.com/ashutoshsinghpr7/wikiskill-hermes


### PR DESCRIPTION
Adds the missing documentation site:\n\n- mkdocs-material site (dark/light, nav) built by CI and deployed to GitHub Pages on every main push\n- landing page with the loop, why-this-repo, quickstart\n- docs/CRON.md: overnight evolution guide (pairs with the shipped cron job)\n- README link + site/ gitignored