### PR TITLE
release workflow: tags → build → GitHub Release (+PyPI-ready)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist + wheel
+        run: |
+          pip install -q build
+          python -m build
+      - name: Publish release with artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*
+      - name: Publish to PyPI (when PYPI_TOKEN is configured)
+        if: ${{ secrets.PYPI_TOKEN != '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
On every `v*` tag:\n\n- builds sdist + wheel in CI (clean ubuntu build)\n- creates a GitHub Release with both artifacts + generated notes\n- publishes to PyPI automatically **only when the `PYPI_TOKEN` secret is configured** (safe by default — skipped otherwise)\n\nPyPI publishing is the one remaining manual step for full distribution: add the secret once (one-time, user action).