### PR TITLE
fix(release): secrets context in if: (actionlint-verified)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ permissions:
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
+    env:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -26,7 +28,7 @@ jobs:
           generate_release_notes: true
           files: dist/*
       - name: Publish to PyPI (when PYPI_TOKEN is configured)
-        if: secrets.PYPI_TOKEN != ''
+        if: env.PYPI_TOKEN != ''
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_TOKEN }}
+          password: ${{ env.PYPI_TOKEN }}


### PR DESCRIPTION
Root cause of the parse failures: `if: secrets.PYPI_TOKEN != ''` — the secrets context is not allowed in step-level `if:` conditions; GitHub rejects the whole workflow file. Fixed by mapping the secret to a job-level env var and using `env.PYPI_TOKEN`. Verified with actionlint before pushing this time.