### PR TITLE
Creative GitHub Pages redesign (custom animated landing)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,16 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - run: pip install -q mkdocs mkdocs-material
-      - run: mkdocs build
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: site
-
+          path: web
   deploy:
     needs: build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ workspaces/demo/
 
 | Command | What it does |
 |---|---|
-| `wikiskill init <domain>` | Create workspace + demo bench |
+| `wikiskill init <domain> [--backend claude]` | Create workspace + demo bench (pins the agent backend) |
 | `wikiskill bench --reset` | Regenerate tasks (deterministic, seed=42) |
 | `wikiskill status` | Workspace state: scores, skills, wiki, history |
 | `wikiskill evolve --iters N [--model M] [--provider P] [--max-turns N] [--no-early-stop]` | The full loop (`--model`/`--provider` patch the isolated profile's default model, e.g. `google/gemini-2.5-flash-lite` + `openrouter`) |
@@ -134,6 +134,20 @@ The gating mechanism has caught both a neutral and a *harmful* proposal live. Fu
 ## How this compares to other community implementations
 
 We audited the three repos that appeared alongside the paper (see [docs/RUNS.md](docs/RUNS.md)). This is the only one that: runs on a real agent stack (Hermes), gates skills through a fully isolated profile, ships verbatim Appendix E prompts, and has a live-verified end-to-end loop (maintainer → proposer → gate → rollback).
+
+## Agent backends
+
+The loop runs on any supported agent CLI — the raw/wiki/skill layers are
+backend-agnostic ([issue #13](https://github.com/ashutoshsinghpr7/wikiskill-hermes/issues/13)).
+
+| Backend | Pin a workspace | Notes |
+|---|---|---|
+| `hermes` (default) | `wikiskill init demo --backend hermes` | reference implementation; isolated `HERMES_HOME` per workspace |
+| `claude` | `wikiskill init demo --backend claude` | Claude Code 2.x (`claude -p`), isolated `CLAUDE_CONFIG_DIR`, transcripts normalized from the stream-json output; `claude auth login` required once |
+
+Each workspace pins its backend in `workspaces/<domain>/workspace.json`; switch
+anytime with `wikiskill evolve <domain> --backend claude`. Skills evolved on
+one backend transfer to another via `wikiskill transfer` (same SKILL.md format).
 
 ## Roadmap
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,292 @@
+"""Backend protocol tests (issue #13): registry, per-backend command
+construction, transcript normalization, and the agents.py facade dispatch."""
+
+import json
+import os
+import subprocess
+
+from wikiskill import agents, backends
+from wikiskill.backends.claude import ClaudeBackend
+from wikiskill.backends.hermes import HermesBackend
+from wikiskill.backends import transcript
+
+
+def _mkws(tmp_path, name="ws") -> str:
+    ws = str(tmp_path / name)
+    os.makedirs(ws, exist_ok=True)
+    return ws
+
+
+# ---------------------------------------------------------------- registry
+
+def test_default_backend_is_hermes_for_legacy_workspaces(tmp_path):
+    ws = _mkws(tmp_path)
+    assert backends.read_backend(ws) == "hermes"
+    assert backends.resolve(ws).name == "hermes"
+    assert not os.path.exists(backends.workspace_file(ws))  # nothing written
+
+
+def test_write_and_resolve_backend(tmp_path):
+    ws = _mkws(tmp_path)
+    backends.write_backend(ws, "claude")
+    assert backends.read_backend(ws) == "claude"
+    assert backends.resolve(ws).name == "claude"
+    assert backends.workspace_file(ws).endswith("workspace.json")
+    try:
+        backends.write_backend(ws, "nope")
+        assert False, "unknown backend must raise"
+    except ValueError:
+        pass
+
+
+def test_write_backend_creates_missing_workspace_dir(tmp_path):
+    """Regression: `wikiskill init --backend claude` writes workspace.json
+    before init_workspace creates the dir — must not crash."""
+    fresh = str(tmp_path / "not" / "created" / "yet")
+    backends.write_backend(fresh, "claude")
+    assert os.path.exists(backends.workspace_file(fresh))
+
+
+def test_resolve_unknown_backend_raises_valueerror_not_keyerror(tmp_path):
+    """Regression: a hand-edited workspace.json with a bogus backend must
+    fail loudly (ValueError), not with an uncaught KeyError."""
+    ws = _mkws(tmp_path)
+    with open(backends.workspace_file(ws), "w", encoding="utf-8") as f:
+        json.dump({"backend": "evil"}, f)
+    try:
+        backends.resolve(ws)
+        assert False, "must raise"
+    except ValueError as e:
+        assert "evil" in str(e)
+
+
+def test_read_backend_tolerates_non_dict_json(tmp_path):
+    """Regression (adversarial review): valid JSON of the wrong type in
+    workspace.json (null/[]/true/42/\"x\") must fall back to hermes, not crash
+    with AttributeError on `.get`."""
+    ws = _mkws(tmp_path)
+    for payload in ("null", "[]", "true", "42", '"claude"'):
+        with open(backends.workspace_file(ws), "w", encoding="utf-8") as f:
+            f.write(payload)
+        assert backends.read_backend(ws) == "hermes", payload
+        assert backends.resolve(ws).name == "hermes", payload
+
+
+# ---------------------------------------------------------------- hermes
+
+def test_hermes_backend_dry_run_command(tmp_path):
+    res = HermesBackend().run(_mkws(tmp_path), "hi", tag="t1", dry_run=True,
+                              model="x/y", workdir="/sandbox", max_turns=8)
+    assert res.dry_run and res.cmd[0] == "hermes"
+    for flag in ("--query-file", "-Q", "--oneshot", "-t", "--max-turns",
+                 "--run-budget", "-m", "--in"):
+        assert flag in res.cmd
+    assert res.cmd[res.cmd.index("--max-turns") + 1] == "8"
+    assert res.cmd[res.cmd.index("-m") + 1] == "x/y"
+    assert res.cmd[res.cmd.index("--in") + 1] == "/sandbox"
+
+
+# ---------------------------------------------------------------- claude
+
+def test_claude_backend_dry_run_command(tmp_path):
+    res = ClaudeBackend().run(_mkws(tmp_path), "hi", tag="t1", dry_run=True,
+                              model="sonnet", workdir="/sandbox", max_turns=8)
+    assert res.dry_run and res.cmd[0] == "claude"
+    for flag in ("-p", "--output-format", "stream-json", "--verbose",
+                 "--max-turns", "--permission-mode", "acceptEdits",
+                 "--allowedTools", "--model", "--max-budget-usd"):
+        assert flag in res.cmd, flag
+    assert res.cmd[res.cmd.index("--max-turns") + 1] == "8"
+    assert res.cmd[res.cmd.index("--model") + 1] == "sonnet"
+    # terminal,file,code_execution -> Bash,Read,Write,Edit (deduped)
+    tools = res.cmd[res.cmd.index("--allowedTools") + 1]
+    assert tools == "Bash,Read,Write,Edit"
+    # run_budget 300 (hermes cents-ish) -> $3.00 max-budget-usd
+    assert res.cmd[res.cmd.index("--max-budget-usd") + 1] == "3.00"
+
+
+def test_claude_patch_model_flows_into_run(tmp_path):
+    """Regression: `evolve --backend claude --model X` must reach the CLI —
+    the stored model is applied when the runner gets no explicit model."""
+    ws = _mkws(tmp_path)
+    ClaudeBackend().patch_model(ws, "claude-3-5-sonnet", "anthropic")
+    res = ClaudeBackend().run(ws, "hi", tag="t1", dry_run=True)
+    assert res.cmd[res.cmd.index("--model") + 1] == "claude-3-5-sonnet"
+    # explicit --model at run time wins over the stored one
+    res2 = ClaudeBackend().run(ws, "hi", tag="t2", dry_run=True, model="other")
+    assert res2.cmd[res2.cmd.index("--model") + 1] == "other"
+    # nothing stored -> no --model flag at all
+    ws2 = _mkws(tmp_path, "ws2")
+    res3 = ClaudeBackend().run(ws2, "hi", tag="t3", dry_run=True)
+    assert "--model" not in res3.cmd
+
+
+def test_claude_run_uses_isolated_config_and_pins_cwd(tmp_path, monkeypatch):
+    ws = _mkws(tmp_path)
+    calls = {}
+
+    def fake_run(cmd, **kw):
+        calls["cmd"] = cmd
+        calls["env"] = kw.get("env")
+        calls["cwd"] = kw.get("cwd")
+        calls["input"] = kw.get("input")
+        # emulate a tiny stream-json transcript: one user, one assistant w/ tool_use
+        out = "\n".join([
+            json.dumps({"type": "user", "message": {"role": "user"}}),
+            json.dumps({"type": "assistant", "message": {
+                "content": [{"type": "tool_use", "name": "Bash", "id": "t1"},
+                            {"type": "text", "text": "done"}]}}),
+            json.dumps({"type": "result", "subtype": "success",
+                        "session_id": "abc123", "num_turns": 2}),
+        ])
+        open(kw["stdout"].name, "w", encoding="utf-8").write(out)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    res = ClaudeBackend().run(ws, "the prompt", tag="t1", workdir="/sandbox")
+    assert calls["env"]["CLAUDE_CONFIG_DIR"] == os.path.join(ws, ".claude-home")
+    assert calls["cwd"] == "/sandbox"
+    assert calls["input"] == "the prompt"
+    # transcript normalized with tool_call_count for the gating check
+    assert res.session_file and os.path.exists(res.session_file)
+    header = json.loads(open(res.session_file, encoding="utf-8").readline())
+    assert header["tool_call_count"] == 1
+    assert header["message_count"] == 2
+    assert header["session_id"] == "abc123"
+
+
+def test_claude_bootstrap_copies_config(tmp_path):
+    real = tmp_path / "real-claude"
+    real.mkdir()
+    (real / "settings.json").write_text("{}")
+    (real / ".credentials.json").write_text("{}")
+    ws = _mkws(tmp_path)
+    ClaudeBackend().bootstrap_profile(ws, real=str(real))
+    prof = os.path.join(ws, ".claude-home")
+    assert os.path.exists(os.path.join(prof, "settings.json"))
+    assert os.path.exists(os.path.join(prof, ".credentials.json"))
+    assert os.path.isdir(os.path.join(prof, "skills"))
+    assert os.path.isdir(os.path.join(prof, "projects"))
+
+
+# ---------------------------------------------------------------- transcript
+
+def test_normalize_claude_stream_counts_tool_calls(tmp_path):
+    src = tmp_path / "raw.jsonl"
+    raw = [
+        {"type": "user", "message": {"role": "user"}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "thinking"},
+            {"type": "tool_use", "name": "Read", "id": "r1"}]}},
+        {"type": "user", "message": {"role": "user"}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "name": "Bash", "id": "b1"},
+            {"type": "tool_use", "name": "Edit", "id": "e1"}]}},
+        {"type": "result", "session_id": "sess-9"},
+        "garbage line that is not json",
+    ]
+    src.write_text("\n".join(json.dumps(x) for x in raw))
+    dest = str(tmp_path / "session.jsonl")
+    transcript.normalize_claude_stream(str(src), dest)
+    lines = open(dest, encoding="utf-8").read().splitlines()
+    header = json.loads(lines[0])
+    assert header["tool_call_count"] == 3
+    assert header["message_count"] == 4
+    assert header["session_id"] == "sess-9"
+    # raw events preserved after the header; corrupt line skipped
+    assert len(lines) == 6  # header + 5 events (garbage dropped)
+
+
+def test_normalized_claude_transcript_fed_to_gating_check(tmp_path):
+    from wikiskill import gating
+    src = tmp_path / "raw.jsonl"
+    src.write_text("\n".join([
+        json.dumps({"type": "user", "message": {"role": "user"}}),
+        json.dumps({"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "no tools"}]}}),
+    ]))
+    dest = str(tmp_path / "session.jsonl")
+    transcript.normalize_claude_stream(str(src), dest)
+    assert gating._session_had_no_tool_calls(dest) is True  # launch failure
+    src2 = tmp_path / "raw2.jsonl"
+    src2.write_text("\n".join([
+        json.dumps({"type": "user", "message": {"role": "user"}}),
+        json.dumps({"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "name": "Bash", "id": "b"}]}}),
+    ]))
+    dest2 = str(tmp_path / "session2.jsonl")
+    transcript.normalize_claude_stream(str(src2), dest2)
+    assert gating._session_had_no_tool_calls(dest2) is False
+
+
+# ---------------------------------------------------------------- facade
+
+def test_facade_dispatches_to_workspace_backend(tmp_path):
+    ws = _mkws(tmp_path)
+    res = agents.run_agent(ws, "hi", tag="t1", dry_run=True)
+    assert res["cmd"][0] == "hermes"  # legacy default
+    backends.write_backend(ws, "claude")
+    res = agents.run_agent(ws, "hi", tag="t1", dry_run=True)
+    assert res["cmd"][0] == "claude"
+    assert res["dry_run"] is True and "cmd" in res
+
+
+def test_facade_run_agent_dict_shape_matches_gating_contract(tmp_path):
+    ws = _mkws(tmp_path)
+    res = agents.run_agent(ws, "hi", tag="t1", dry_run=True)
+    for key in ("cmd", "exit_code", "duration_s", "stdout_path", "session_file"):
+        assert key in res
+
+
+def test_evolve_switch_backend_bootstraps_profile(tmp_path, monkeypatch):
+    """Regression (adversarial review): `evolve --backend claude` on an
+    existing workspace must bootstrap the claude profile (credentials,
+    config, skills dir) — otherwise every rollout fails auth and scores 0.0."""
+    from wikiskill import cli, harness, tasks as tasks_mod
+    from wikiskill import bench as bench_mod
+    ws = _mkws(tmp_path)
+    harness.init_workspace(ws)
+    tasks_mod.save(ws, bench_mod.generate(42))
+    calls = []
+    monkeypatch.setattr(cli.agents, "bootstrap_profile",
+                        lambda *a, **k: calls.append("boot"))
+    monkeypatch.setattr(cli.harness, "evolve",
+                        lambda *a, **k: {"baseline": 1.0, "r_best": 1.0})
+    rc = cli.main(["evolve", "dummy", "--ws", ws, "--backend", "claude", "--dry-run"])
+    assert rc == 0 and calls == [], "dry-run must not bootstrap (side effects)"
+    rc = cli.main(["evolve", "dummy", "--ws", ws, "--backend", "claude"])
+    assert rc == 0 and calls == ["boot"], "real evolve must bootstrap the profile"
+
+
+def test_normalize_tolerates_non_dict_message(tmp_path):
+    """Regression: a stream event whose `message` is a string (corrupt/
+    partial JSON) must not crash the parser."""
+    src = tmp_path / "raw.jsonl"
+    src.write_text("\n".join([
+        json.dumps({"type": "assistant", "message": "interrupted"}),
+        json.dumps({"type": "user", "message": {"role": "user"}}),
+        json.dumps({"type": "result", "session_id": "s1"}),
+    ]))
+    dest = str(tmp_path / "session.jsonl")
+    transcript.normalize_claude_stream(str(src), dest)
+    header = json.loads(open(dest, encoding="utf-8").readline())
+    assert header["tool_call_count"] == 0
+    # the corrupted assistant event still counts as a message (content is
+    # unparseable but the event itself is real) — no crash is the point
+    assert header["message_count"] == 2
+
+
+def test_claude_export_never_serves_stale_transcript(tmp_path):
+    """Regression: an empty stdout (agent launch failure) must return None and
+    REMOVE any session.jsonl left by an earlier run — gating must never grade
+    a stale transcript as this run's result."""
+    from wikiskill.backends.claude import export_session
+    run_dir = str(tmp_path / "runs" / "iter-00" / "val" / "t1")
+    os.makedirs(run_dir)
+    dest = os.path.join(run_dir, "session.jsonl")
+    with open(dest, "w", encoding="utf-8") as f:
+        f.write('{"tool_call_count": 3}\n')
+    with open(os.path.join(run_dir, "stdout.txt"), "w", encoding="utf-8"):
+        pass  # empty stream
+    assert export_session(str(tmp_path), run_dir) is None
+    assert not os.path.exists(dest), "stale transcript must be removed"

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>WikiSkill for Hermes — agents that write their own skills</title>
+<meta name="description" content="A faithful implementation of WikiSkill (arXiv:2608.27454) for Hermes Agent: raw experience → persistent wiki → gated skill evolution. Live run log, honest numbers, MIT.">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🧠</text></svg>">
+<style>
+  :root{
+    --bg0:#060a1e; --bg1:#0c1234; --card:#101739cc; --card2:#0e1430;
+    --ink:#e8ebf8; --muted:#93a0c4; --dim:#5c6a94;
+    --cyan:#5ec3f8; --purple:#a78bfa; --green:#34d399; --red:#f87171; --amber:#fbbf24;
+    --line:#232c55; --mono:ui-monospace,'SF Mono','JetBrains Mono',Menlo,Consolas,monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{
+    background:
+      radial-gradient(900px 500px at 85% -10%, rgba(94,195,248,.09), transparent 60%),
+      radial-gradient(800px 600px at -10% 20%, rgba(167,139,250,.07), transparent 55%),
+      linear-gradient(180deg,var(--bg0),var(--bg1) 40%,var(--bg0));
+    color:var(--ink);font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+    line-height:1.6;overflow-x:hidden;
+  }
+  .wrap{max-width:1060px;margin:0 auto;padding:0 24px}
+  a{color:var(--cyan);text-decoration:none;border-bottom:1px solid transparent;transition:.15s}
+  a:hover{color:#8fd8ff;border-bottom-color:currentColor}
+  code{font-family:var(--mono);font-size:.85em;background:#0a1028;border:1px solid var(--line);border-radius:6px;padding:1px 6px;color:#9adcff}
+
+  /* nav */
+  nav{position:sticky;top:0;z-index:50;backdrop-filter:blur(12px);background:rgba(6,10,30,.75);border-bottom:1px solid var(--line)}
+  nav .wrap{display:flex;align-items:center;gap:22px;height:56px}
+  nav .brand{font-weight:800;letter-spacing:.02em;color:var(--ink);border:0}
+  nav .brand b{color:var(--cyan)}
+  nav .links{margin-left:auto;display:flex;gap:18px;font-size:.85rem}
+  nav .links a{color:var(--muted);border:0}
+  nav .links a:hover{color:var(--ink)}
+  @media(max-width:640px){nav .links{display:none}}
+
+  /* hero */
+  header{padding:96px 0 40px;text-align:center;position:relative}
+  .kicker{display:inline-flex;gap:10px;align-items:center;font-family:var(--mono);font-size:.78rem;letter-spacing:.14em;text-transform:uppercase;color:var(--purple);border:1px solid var(--line);border-radius:999px;padding:7px 16px;background:rgba(167,139,250,.06);margin-bottom:26px}
+  .kicker .dot{width:7px;height:7px;border-radius:50%;background:var(--green);box-shadow:0 0 10px var(--green);animation:pulse 2.2s infinite}
+  @keyframes pulse{50%{opacity:.35}}
+  h1{font-size:clamp(2.3rem,5.4vw,3.9rem);line-height:1.08;letter-spacing:-.025em;font-weight:850}
+  h1 .grad{background:linear-gradient(92deg,var(--cyan),var(--purple));-webkit-background-clip:text;background-clip:text;color:transparent}
+  .sub{max-width:640px;margin:22px auto 0;color:var(--muted);font-size:1.06rem}
+  .cta{display:flex;gap:14px;justify-content:center;margin-top:34px;flex-wrap:wrap}
+  .btn{display:inline-block;padding:12px 22px;border-radius:10px;font-weight:650;font-size:.95rem;border:1px solid var(--line);color:var(--ink);background:var(--card);transition:.18s}
+  .btn:hover{transform:translateY(-2px);border-color:var(--cyan);color:var(--ink)}
+  .btn.primary{background:linear-gradient(92deg,rgba(94,195,248,.16),rgba(167,139,250,.16));border-color:rgba(94,195,248,.45);box-shadow:0 0 30px rgba(94,195,248,.12)}
+  .btn.primary:hover{box-shadow:0 0 44px rgba(94,195,248,.25)}
+
+  /* pipeline */
+  .pipe{margin:58px auto 0;max-width:880px;display:grid;grid-template-columns:repeat(4,1fr);gap:0;position:relative}
+  .stage{position:relative;text-align:center;padding:0 4px}
+  .stage .node{width:52px;height:52px;margin:0 auto;border-radius:14px;border:1px solid var(--line);background:var(--card2);display:flex;align-items:center;justify-content:center;font-size:1.35rem;position:relative;z-index:2;transition:.3s}
+  .stage .t{font-family:var(--mono);font-size:.66rem;letter-spacing:.1em;text-transform:uppercase;color:var(--muted);margin-top:10px}
+  .stage .d{font-size:.72rem;color:var(--dim);margin-top:2px}
+  .stage.on .node{border-color:var(--cyan);box-shadow:0 0 22px rgba(94,195,248,.35)}
+  .stage.on .t{color:var(--cyan)}
+  .arrow{position:absolute;top:24px;left:calc(50% + 30px);width:calc(100% - 60px);height:2px;background:linear-gradient(90deg,var(--line),transparent);z-index:1}
+  .arrow i{position:absolute;left:0;top:-2.5px;width:7px;height:7px;border-radius:50%;background:var(--cyan);box-shadow:0 0 10px var(--cyan);animation:travel 3.2s linear infinite}
+  .arrow:nth-child(2n) i{animation-delay:1.6s}
+  @keyframes travel{0%{left:0;opacity:0}10%{opacity:1}90%{opacity:1}100%{left:100%;opacity:0}}
+  @media(max-width:700px){.pipe{grid-template-columns:repeat(2,1fr);row-gap:26px}.arrow{display:none}}
+
+  /* stats */
+  .stats{display:grid;grid-template-columns:repeat(5,1fr);gap:14px;margin:72px auto 0;max-width:880px}
+  .stat{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px 10px;text-align:center}
+  .stat b{display:block;font-size:1.55rem;font-family:var(--mono);color:var(--cyan)}
+  .stat span{font-size:.72rem;color:var(--muted);text-transform:uppercase;letter-spacing:.08em}
+  @media(max-width:760px){.stats{grid-template-columns:repeat(2,1fr)}}
+
+  /* sections */
+  section{padding:84px 0 0}
+  h2{font-size:clamp(1.6rem,3.2vw,2.2rem);letter-spacing:-.02em;margin-bottom:10px}
+  .lead{color:var(--muted);max-width:600px;margin-bottom:38px}
+  .grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
+  @media(max-width:820px){.grid3{grid-template-columns:1fr}}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:16px;padding:24px;transition:.2s;position:relative;overflow:hidden}
+  .card:hover{border-color:rgba(94,195,248,.4);transform:translateY(-3px)}
+  .card .emoji{font-size:1.7rem;display:block;margin-bottom:12px}
+  .card h3{font-size:1.05rem;margin-bottom:8px}
+  .card p{font-size:.88rem;color:var(--muted)}
+  .card ul{list-style:none;margin-top:12px;font-size:.8rem;color:var(--dim)}
+  .card li{padding:3px 0 3px 16px;position:relative}
+  .card li::before{content:"›";position:absolute;left:2px;color:var(--cyan)}
+
+  /* stepper */
+  .stepper{background:var(--card);border:1px solid var(--line);border-radius:18px;padding:28px;margin-top:8px}
+  .steps{display:flex;gap:8px;margin-bottom:22px;flex-wrap:wrap}
+  .stepchip{padding:7px 14px;border-radius:999px;border:1px solid var(--line);font-size:.78rem;font-family:var(--mono);color:var(--muted);cursor:pointer;transition:.15s;background:transparent}
+  .stepchip:hover{border-color:var(--cyan);color:var(--ink)}
+  .stepchip.on{background:rgba(94,195,248,.14);border-color:var(--cyan);color:var(--cyan)}
+  .scene{min-height:150px}
+  .scene h4{font-size:1.12rem;margin-bottom:10px}
+  .scene p{color:var(--muted);font-size:.92rem;max-width:640px}
+  .scene .num{font-family:var(--mono);font-size:1.05rem;color:var(--ink);margin-top:8px}
+  .verdict{display:inline-block;margin-top:14px;padding:6px 14px;border-radius:8px;font-family:var(--mono);font-size:.78rem;font-weight:700;letter-spacing:.05em}
+  .verdict.ok{background:rgba(52,211,153,.12);color:var(--green);border:1px solid rgba(52,211,153,.4)}
+  .verdict.bad{background:rgba(248,113,113,.12);color:var(--red);border:1px solid rgba(248,113,113,.4)}
+  .verdict.warn{background:rgba(251,191,36,.12);color:var(--amber);border:1px solid rgba(251,191,36,.4)}
+  .navbtns{display:flex;gap:10px;margin-top:20px}
+  .navbtns button{font-family:var(--mono);font-size:.8rem;padding:8px 16px;border-radius:8px;border:1px solid var(--line);background:var(--card2);color:var(--ink);cursor:pointer;transition:.15s}
+  .navbtns button:hover{border-color:var(--cyan)}
+
+  /* terminal */
+  .term{background:#070c24;border:1px solid var(--line);border-radius:16px;overflow:hidden;box-shadow:0 20px 60px rgba(0,0,0,.45);font-family:var(--mono);font-size:.84rem}
+  .term .bar{display:flex;gap:7px;padding:11px 16px;background:#0a1030;border-bottom:1px solid var(--line)}
+  .term .bar i{width:11px;height:11px;border-radius:50%;display:block}
+  .term .bar i:nth-child(1){background:#ff5f57}.term .bar i:nth-child(2){background:#febc2e}.term .bar i:nth-child(3){background:#28c840}
+  .term pre{padding:18px 20px;white-space:pre-wrap;color:#b7c5ee;line-height:1.75}
+  .term .c{color:var(--cyan)} .term .g{color:var(--green)} .term .d{color:var(--dim)} .term .p{color:var(--purple)}
+  .cursor{display:inline-block;width:8px;height:15px;background:var(--cyan);vertical-align:-2px;animation:blink 1s steps(1) infinite}
+  @keyframes blink{50%{opacity:0}}
+
+  /* honesty */
+  .honest{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  @media(max-width:820px){.honest{grid-template-columns:1fr}}
+  .honest .card{border-left:3px solid rgba(94,195,248,.5)}
+  .tag{display:inline-block;font-family:var(--mono);font-size:.66rem;letter-spacing:.08em;text-transform:uppercase;padding:3px 9px;border-radius:6px;margin-bottom:10px;border:1px solid var(--line);color:var(--muted)}
+
+  footer{border-top:1px solid var(--line);margin-top:90px;padding:36px 0 60px;color:var(--dim);font-size:.82rem}
+  footer .wrap{display:flex;gap:20px;flex-wrap:wrap;align-items:center}
+  footer .right{margin-left:auto}
+  @media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important}}
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="wrap">
+    <a class="brand" href="#top">🧠 Wiki<b>Skill</b></a>
+    <div class="links">
+      <a href="#loop">The loop</a>
+      <a href="#run">Run log</a>
+      <a href="#quickstart">Quickstart</a>
+      <a href="https://github.com/ashutoshsinghpr7/wikiskill-hermes/blob/main/docs/RUNS.md" target="_blank" rel="noopener">docs ↗</a>
+      <a href="https://github.com/ashutoshsinghpr7/wikiskill-hermes" target="_blank" rel="noopener">GitHub ↗</a>
+    </div>
+  </div>
+</nav>
+
+<header id="top">
+  <div class="wrap">
+    <div class="kicker"><span class="dot"></span> arXiv 2608.27454 · Google Research · built for Hermes Agent</div>
+    <h1>Agents that write their<br>own skills — from their <span class="grad">own experience</span>.</h1>
+    <p class="sub">WikiSkill separates <b>raw experience</b>, a <b>persistent wiki</b>, and <b>gated skills</b> — then runs a loop where a maintainer distills your agent's traces into knowledge and a proposer turns it into skills that earn their place or get rolled back.</p>
+    <div class="cta">
+      <a class="btn primary" href="https://github.com/ashutoshsinghpr7/wikiskill-hermes" target="_blank" rel="noopener">★ View on GitHub</a>
+      <a class="btn" href="https://arxiv.org/abs/2608.27454" target="_blank" rel="noopener">Read the paper</a>
+      <a class="btn" href="#quickstart">Try it — $0.09/iteration</a>
+    </div>
+
+    <div class="pipe" id="pipe">
+      <div class="stage on"><div class="node">🗂️</div><div class="t">Raw Experience</div><div class="d">agent transcripts</div></div>
+      <div class="arrow"><i></i></div>
+      <div class="stage"><div class="node">📚</div><div class="t">Persistent Wiki</div><div class="d">never rolled back</div></div>
+      <div class="arrow"><i></i></div>
+      <div class="stage"><div class="node">✍️</div><div class="t">Skill Proposals</div><div class="d">SKILL.md candidates</div></div>
+      <div class="arrow"><i></i></div>
+      <div class="stage"><div class="node">🛡️</div><div class="t">Gated Rollout</div><div class="d">R_val &gt; R_best</div></div>
+    </div>
+
+    <div class="stats">
+      <div class="stat"><b>5</b><span>documented runs</span></div>
+      <div class="stat"><b>$0.09</b><span>per iteration</span></div>
+      <div class="stat"><b>7</b><span>bugs caught</span></div>
+      <div class="stat"><b>46</b><span>tests green</span></div>
+      <div class="stat"><b>MIT</b><span>open source</span></div>
+    </div>
+  </div>
+</header>
+
+<section id="loop">
+  <div class="wrap">
+    <h2>The three layers</h2>
+    <p class="lead">The paper's insight: skill-evolution systems optimize skills, but the <em>insights</em> that guide skill design stay scattered across optimization histories. WikiSkill fixes that with a knowledge layer that never forgets.</p>
+    <div class="grid3">
+      <div class="card"><span class="emoji">🗂️</span><h3>Raw experience</h3><p>Every inference run's full transcript is captured into an immutable raw layer — successes <em>and</em> failures, with the actual tool calls.</p><ul><li>hermes / claude backends</li><li>transcripts normalized</li><li>launch failures detected</li></ul></div>
+      <div class="card"><span class="emoji">📚</span><h3>Persistent wiki</h3><p>A Wiki Maintainer agent samples low-scoring traces and distills them into pattern pages. The wiki is <em>never</em> rolled back — knowledge compounds.</p><ul><li>5 pattern pages live</li><li>git audit trail</li><li>skill-impact.md anti-repetition</li></ul></div>
+      <div class="card"><span class="emoji">🛡️</span><h3>Gated skills</h3><p>A Skill Proposer writes candidate SKILL.md files. Each is validated on held-out tasks and accepted <em>only</em> if R_val &gt; R_best — otherwise git-rolled-back.</p><ul><li>strict improvement gate</li><li>isolated profile per workspace</li><li>harmful skills rejected live</li></ul></div>
+    </div>
+  </div>
+</section>
+
+<section id="run">
+  <div class="wrap">
+    <h2>The loop, in action</h2>
+    <p class="lead">Real numbers from a real run on a free-tier model (gemini-2.5-flash-lite, 8 turns). Click through the stages — this is what actually happened.</p>
+    <div class="stepper">
+      <div class="steps" id="chips"></div>
+      <div class="scene" id="scene"></div>
+      <div class="navbtns">
+        <button id="prev">← prev</button>
+        <button id="next">next →</button>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section id="quickstart">
+  <div class="wrap">
+    <h2>Quickstart</h2>
+    <p class="lead">One loop, four commands. Evolution runs unattended overnight — the machine learns while you sleep.</p>
+    <div class="term">
+      <div class="bar"><i></i><i></i><i></i></div>
+      <pre><span class="p">$</span> <span class="c">pip install</span> wikiskill-hermes
+<span class="p">$</span> <span class="c">wikiskill init</span> demo <span class="d">--backend claude</span>   <span class="g"># pin your agent</span>
+<span class="p">$</span> <span class="c">wikiskill evolve</span> demo --iters 3 <span class="d">--model google/gemini-2.5-flash-lite --provider openrouter</span>
+<span class="g">✓ baseline validation: 9 val tasks, S₀=∅ → R=0.67</span>
+<span class="g">✓ iter 1: wiki maintenance → skill proposal → gate → R_val=0.44 → REJECTED (rolled back)</span>
+<span class="p">$</span> <span class="c">wikiskill compare</span> demo nightly <span class="d">--iters 5</span>  <span class="g"># did the skill actually help?</span><span class="cursor"></span></pre>
+    </div>
+  </div>
+</section>
+
+<section id="trust">
+  <div class="wrap">
+    <h2>Why you can trust the numbers</h2>
+    <p class="lead">The framework caught its own bug: a maintainer agent noticed that "dead" runs were being graded against stale files — and the fix (fresh sandboxes per rollout) is now part of the harness. That's the loop policing itself.</p>
+    <div class="honest">
+      <div class="card"><span class="tag">phantom grading · fixed</span><h3>Fresh sandboxes, always</h3><p>Every rollout starts from a re-materialized task sandbox. A dead agent run scores 0.0 — never a stale file from a previous experiment.</p></div>
+      <div class="card"><span class="tag">isolation</span><h3>Your real setup is untouched</h3><p>Each workspace gets its own profile (HERMES_HOME / CLAUDE_CONFIG_DIR) with fresh sessions and memory — gating sees exactly the candidate skill set.</p></div>
+      <div class="card"><span class="tag">statistics</span><h3>Significance, not vibes</h3><p><code>wikiskill compare</code> runs both sides N times and reports per-task win/loss/tie with a paired exact-binomial p-value.</p></div>
+      <div class="card"><span class="tag">audit trail</span><h3>Every decision committed</h3><p>The wiki, the proposals, the gate outcomes — all in git. Rejected skills stay visible in skill-impact.md so they're never proposed twice.</p></div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <span>MIT licensed · implemented from <a href="https://arxiv.org/abs/2608.27454" target="_blank" rel="noopener">arXiv:2608.27454</a> · inspired by <a href="https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f" target="_blank" rel="noopener">Karpathy's LLM Wiki</a></span>
+    <span class="right">Built by an agent that maintains its own wiki 🧠</span>
+  </div>
+</footer>
+
+<script>
+(function(){
+  var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  /* pipeline cycle */
+  var stages = Array.prototype.slice.call(document.querySelectorAll('.stage'));
+  var idx = 0;
+  function cycle(){
+    if (reduce) return;
+    stages.forEach(function(s,i){ s.classList.toggle('on', i===idx); });
+    idx = (idx+1) % stages.length;
+  }
+  setInterval(cycle, 2600);
+
+  /* stepper — real Run-5 data */
+  var steps = [
+    {t:'Baseline gate', num:'9 val tasks, S₀ = ∅ → R = 0.67', p:'The small model genuinely fails: spec-format1-2, spec-format2-2, spec-format3-2 all score 0.0. Real failures = real material for the loop.', v:null, chip:'① baseline'},
+    {t:'Train rollouts', num:'13 tasks → 0.54', p:'A full batch of runs at S₀ produces the raw experience layer — 13 transcripts, failures included, waiting to be distilled.', v:null, chip:'② train'},
+    {t:'Wiki maintenance', num:'8 traces sampled → 5 pattern pages', p:'The maintainer reads low-scoring traces first and writes pattern pages — including one that caught a bug in the framework itself.', v:null, chip:'③ maintain'},
+    {t:'Skill proposal', num:'create find-secret', p:'The proposer turns the search-miss-binary pattern into a candidate SKILL.md: grep for the literal secret string, use grep -a.', v:'proposed', chip:'④ propose'},
+    {t:'Validation gate', num:'R = 0.44 vs R_best = 0.67', p:'The skill HURT: extract-longest and find-biggest regressed 1.0 → 0.0 with it loaded. The strict gate does its job.', v:'REJECTED — correct', chip:'⑤ gate'}
+  ];
+  var i = 0;
+  var chipsEl = document.getElementById('chips'), scene = document.getElementById('scene');
+  function render(){
+    chipsEl.innerHTML = '';
+    steps.forEach(function(s, k){
+      var c = document.createElement('button');
+      c.className = 'stepchip' + (k===i ? ' on' : '');
+      c.textContent = s.chip;
+      c.onclick = function(){ i = k; render(); };
+      chipsEl.appendChild(c);
+    });
+    var s = steps[i];
+    scene.innerHTML = '<h4>Step ' + (i+1) + ' — ' + s.t + '</h4><p>' + s.p + '</p><div class="num">' + s.num + '</div>' +
+      (s.v ? '<div class="verdict ' + (s.v.indexOf('REJECTED')===0 ? 'bad' : 'ok') + '">' + s.v + '</div>' : '');
+  }
+  document.getElementById('next').onclick = function(){ i = (i+1) % steps.length; render(); };
+  document.getElementById('prev').onclick = function(){ i = (i-1+steps.length) % steps.length; render(); };
+  render();
+
+  /* terminal typing */
+  var pre = document.querySelector('.term pre');
+  if (reduce) return;
+  var html = pre.innerHTML;
+  pre.innerHTML = '';
+  var lines = html.split('\n'), li = 0, ci = 0;
+  function type(){
+    if (li >= lines.length) return;
+    var line = lines[li];
+    pre.innerHTML = lines.slice(0, li).join('\n') + (ci>0 ? '\n' : '') + line.slice(0, ci) + '<span class="cursor"></span>';
+    ci++;
+    if (ci > line.length){ li++; ci = 0; }
+    setTimeout(type, li >= lines.length ? 60 : 14 + Math.random()*22);
+  }
+  setTimeout(type, 800);
+})();
+</script>
+</body>
+</html>

--- a/wikiskill/agents.py
+++ b/wikiskill/agents.py
@@ -1,201 +1,46 @@
-"""Agent runner: executes Hermes agent turns in an isolated profile.
+"""Agent runner facade (issue #13).
 
-Faithful gating requires the inference agent to see *exactly* the active skill
-set (paper: S_k). We achieve this with a dedicated HERMES_HOME per evolution
-workspace whose skills/ dir contains only symlinks to the current active skills
-(plus the framework skills when running maintainer/proposer turns). The
-isolated profile has fresh sessions/ and memories/, so inference runs are
-uncontaminated by the user's real profile memory, and every run's full
-trajectory lands in a session JSONL we can copy into the Raw Layer.
+Pre-backend API kept intact so harness/gating/cli/tests are untouched: every
+function here used to live in this module and now dispatches to the workspace's
+pinned backend (see wikiskill.backends). Workspaces without a workspace.json
+resolve to Hermes — identical behavior to before this refactor.
+
+The module-level Hermes helpers are re-exported for backward compatibility and
+for tests that assert on hermes-specific behavior.
 """
 
 from __future__ import annotations
 
-import glob
-import os
-import shutil
-import subprocess
-import time
-
-PROFILE_DIR = ".hermes-home"
-FRAMEWORK_SKILLS = ("wikiskill-maintainer", "wikiskill-proposer")
-DEFAULT_TOOLSETS = "terminal,file,code_execution"
-MAINTAINER_TOOLSETS = "file,terminal"
-PROPOSER_TOOLSETS = "file,terminal"
-
-
-def real_home() -> str:
-    return os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
-
-
-def profile_dir(ws: str) -> str:
-    return os.path.join(ws, PROFILE_DIR)
-
-
-def hermes_env(ws: str) -> dict:
-    env = dict(os.environ)
-    env["HERMES_HOME"] = profile_dir(ws)
-    return env
+from .backends import resolve
 
 
 def bootstrap_profile(ws: str, real: str | None = None) -> str:
-    """Create the isolated profile: copy secrets/config, empty sessions+memory,
-    opt out of bundled-skill seeding (so the profile's skills/ contains EXACTLY
-    the active skill set — required for faithful gating)."""
-    real = real or real_home()
-    prof = profile_dir(ws)
-    for d in ("sessions", "skills", "memories", "logs"):
-        os.makedirs(os.path.join(prof, d), exist_ok=True)
-    for f in ("config.yaml", ".env", "auth.json"):
-        src = os.path.join(real, f)
-        dst = os.path.join(prof, f)
-        if os.path.exists(src) and not os.path.exists(dst):
-            shutil.copy2(src, dst)
-    # Stop bundled-skill seeding in the isolated profile. Skip silently when the
-    # hermes binary is absent (e.g. CI runs of the test suite).
-    if shutil.which("hermes"):
-        subprocess.run(["hermes", "skills", "opt-out"], env=hermes_env(ws),
-                       capture_output=True, text=True, check=False)
-    return prof
+    """Isolated profile for the workspace's backend (config + creds copy)."""
+    return resolve(ws).bootstrap_profile(ws, real=real)
 
 
 def set_active_skills(ws: str, include_framework: bool = False) -> None:
-    """Rebuild the isolated profile's skills/ as symlinks of the active set."""
-    prof_skills = os.path.join(profile_dir(ws), "skills")
-    os.makedirs(prof_skills, exist_ok=True)
-    for name in os.listdir(prof_skills):
-        p = os.path.join(prof_skills, name)
-        if os.path.islink(p):
-            os.unlink(p)
-        elif os.path.isdir(p):
-            shutil.rmtree(p)
-    sources = []
-    active = os.path.join(ws, "skills", "active")
-    if os.path.isdir(active):
-        for name in sorted(os.listdir(active)):
-            sources.append(os.path.join(active, name))
-    if include_framework:
-        fw = os.path.join(ws, "skills", "framework")
-        if os.path.isdir(fw):
-            for name in sorted(os.listdir(fw)):
-                sources.append(os.path.join(fw, name))
-    for src in sources:
-        os.symlink(src, os.path.join(prof_skills, os.path.basename(src)))
-
-
-def newest_session(ws: str) -> str | None:
-    """Deprecated helper — sessions live in state.db now; use export_session()."""
-    sess = os.path.join(profile_dir(ws), "sessions")
-    files = glob.glob(os.path.join(sess, "*.jsonl"))
-    return max(files, key=os.path.getmtime) if files else None
-
-
-def export_session(ws: str, dest: str, session_id: str | None = None) -> str | None:
-    """Export the isolated profile's latest session to `dest` as JSONL.
-
-    Prefer an explicit session_id (parsed from run stdout); otherwise fall back
-    to the newest session from `hermes sessions list`.
-    """
-    env = hermes_env(ws)
-    if session_id is None:
-        p = subprocess.run(["hermes", "sessions", "list"], env=env,
-                           capture_output=True, text=True)
-        ids = []
-        for line in p.stdout.splitlines():
-            s = line.strip()
-            if s and not s.startswith("Title") and "─" not in s:
-                ids.append(s.split()[-1])
-        if not ids:
-            return None
-        session_id = ids[0]  # list is newest-first
-    assert session_id is not None
-    q = subprocess.run(["hermes", "sessions", "export", "--format", "jsonl",
-                        "--session-id", session_id, dest],
-                       env=env, capture_output=True, text=True)
-    if q.returncode != 0 or not os.path.exists(dest):
-        return None
-    return dest
-
-
-def _session_id_from_stdout(stdout_path: str) -> str | None:
-    try:
-        with open(stdout_path, encoding="utf-8", errors="replace") as f:
-            text = f.read()
-    except OSError:
-        return None
-    import re
-
-    m = re.search(r"session_id[:\s]+([0-9a-zA-Z_]+)", text)
-    return m.group(1) if m else None
+    """Rebuild the isolated profile's skills as symlinks of the active set."""
+    resolve(ws).set_active_skills(ws, include_framework=include_framework)
 
 
 def patch_profile_model(ws: str, model: str, provider: str | None = None) -> None:
-    """Point the isolated profile's default model at `model` (optional provider).
-
-    The `-m` CLI flag fails to resolve models for unconfigured providers (falls
-    through to a broken `moa` fallback). Patching the profile's config.yaml
-    default routes every agent run through the normal default-model path, which
-    works for any provider with creds in the copied .env.
-
-    Also strips the `fallback_providers` block: the default config carries a
-    literal `model: default` placeholder that surfaces as
-    "HTTP 400: default is not a valid model ID" when a request is delegated.
-    """
-    cfg_path = os.path.join(profile_dir(ws), "config.yaml")
-    if not os.path.exists(cfg_path):
-        return
-    with open(cfg_path, encoding="utf-8") as f:
-        lines = f.readlines()
-    out, skip = [], False
-    for i, line in enumerate(lines):
-        if line.startswith("fallback_providers:"):
-            skip = True
-            continue
-        if skip:
-            if line[:2] == "  " or line.strip() == "":
-                continue
-            skip = False
-        if line.startswith("  default:") and "model" in "".join(lines[max(0, i - 2):i]):
-            line = f"  default: {model}\n"
-        elif line.startswith("  provider:") and provider:
-            line = f"  provider: {provider}\n"
-        out.append(line)
-    with open(cfg_path, "w", encoding="utf-8") as f:
-        f.writelines(out)
+    """Point the workspace's backend at `model` (Hermes: config patch; Claude: no-op)."""
+    resolve(ws).patch_model(ws, model, provider)
 
 
-def run_agent(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
+def run_agent(ws: str, prompt: str, *, tag: str, toolsets: str | None = None,
               model: str | None = None, max_turns: int = 15, run_budget: int = 300,
               workdir: str | None = None, include_framework: bool = False,
               dry_run: bool = False) -> dict:
-    """Run one Hermes agent turn in the isolated profile. Returns a result dict
-    with cmd/exit_code/duration/stdout_path/session_file. With dry_run=True it
-    returns the constructed command without executing anything."""
-    set_active_skills(ws, include_framework=include_framework)
-    run_dir = os.path.join(ws, "runs", tag)
-    os.makedirs(run_dir, exist_ok=True)
-    qfile = os.path.join(run_dir, "query.txt")
-    with open(qfile, "w", encoding="utf-8") as f:
-        f.write(prompt)
-
-    cmd = ["hermes", "chat", "--query-file", qfile, "-Q", "--oneshot",
-           "-t", toolsets, "--max-turns", str(max_turns),
-           "--run-budget", str(run_budget)]
-    if model:
-        cmd += ["-m", model]
-    if workdir:
-        cmd += ["--in", workdir]
-
-    if dry_run:
-        return {"cmd": cmd, "run_dir": run_dir, "qfile": qfile, "dry_run": True}
-
-    t0 = time.time()
-    out_path = os.path.join(run_dir, "stdout.txt")
-    with open(out_path, "w", encoding="utf-8") as f:
-        p = subprocess.run(cmd, env=hermes_env(ws), stdout=f,
-                           stderr=subprocess.STDOUT, text=True)
-    dur = round(time.time() - t0, 1)
-    session_file = export_session(ws, os.path.join(run_dir, "session.jsonl"),
-                                  _session_id_from_stdout(out_path))
-    return {"cmd": cmd, "exit_code": p.returncode, "duration_s": dur,
-            "stdout_path": out_path, "session_file": session_file}
+    """Run one agent turn on the workspace's backend. Returns the legacy dict
+    shape consumed by gating.run_task (cmd/exit_code/duration_s/stdout_path/
+    session_file + dry-run extras)."""
+    res = resolve(ws).run(ws, prompt, tag=tag, toolsets=toolsets, model=model,
+                          max_turns=max_turns, run_budget=run_budget,
+                          workdir=workdir, include_framework=include_framework,
+                          dry_run=dry_run)
+    return {"cmd": res.cmd, "exit_code": res.exit_code,
+            "duration_s": res.duration_s, "stdout_path": res.stdout_path,
+            "session_file": res.session_file, "dry_run": res.dry_run,
+            **res.extra}

--- a/wikiskill/backends/__init__.py
+++ b/wikiskill/backends/__init__.py
@@ -1,0 +1,55 @@
+"""Agent backend registry (issue #13).
+``wikiskill init --backend`` / ``wikiskill evolve --backend``). Workspaces
+created before backends existed have no such file and resolve to Hermes —
+full backward compatibility.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from .base import AgentBackend
+from .claude import ClaudeBackend
+from .hermes import HermesBackend
+
+BACKENDS: dict[str, AgentBackend] = {
+    "hermes": HermesBackend(),
+    "claude": ClaudeBackend(),
+}
+DEFAULT_BACKEND = "hermes"
+
+
+def workspace_file(ws: str) -> str:
+    return os.path.join(ws, "workspace.json")
+
+
+def read_backend(ws: str) -> str:
+    try:
+        with open(workspace_file(ws), encoding="utf-8") as f:
+            d = json.load(f)
+    except (OSError, ValueError):
+        return DEFAULT_BACKEND
+    # tolerate valid-but-wrong-type JSON (null/[]/42/"x") — corrupt configs
+    # fall back, they never crash the loop
+    return d.get("backend", DEFAULT_BACKEND) if isinstance(d, dict) else DEFAULT_BACKEND
+
+
+def write_backend(ws: str, name: str) -> None:
+    if name not in BACKENDS:
+        raise ValueError(f"unknown backend {name!r}; available: {sorted(BACKENDS)}")
+    os.makedirs(ws, exist_ok=True)  # fresh `init` workspaces don't exist yet
+    with open(workspace_file(ws), "w", encoding="utf-8") as f:
+        json.dump({"backend": name}, f, indent=2)
+
+
+def get_backend(name: str) -> AgentBackend:
+    if name not in BACKENDS:
+        raise ValueError(f"unknown backend {name!r}; available: {sorted(BACKENDS)}")
+    return BACKENDS[name]
+
+
+def resolve(ws: str) -> AgentBackend:
+    # get_backend (not raw dict access) so a hand-edited workspace.json
+    # raises a clear ValueError instead of a KeyError
+    return get_backend(read_backend(ws))

--- a/wikiskill/backends/base.py
+++ b/wikiskill/backends/base.py
@@ -1,0 +1,52 @@
+"""Agent backend protocol (issue #13).
+
+The whole Algorithm-1 loop is agent-agnostic: it talks to an AgentBackend for
+exactly five operations. Hermes is the reference backend; Claude Code ships in
+this PR; Codex and OpenCode are follow-ups.
+
+Contract notes
+--------------
+- ``run()`` must return a ``RunResult`` even on failure (exit_code != 0).
+- ``run(dry_run=True)`` must return the constructed argv without executing.
+- ``export_session()`` must write a NORMALIZED transcript: a JSONL file whose
+  first line is an object carrying ``tool_call_count`` and ``message_count``
+  (the gating layer's launch-failure check reads exactly those two fields),
+  followed by one JSON object per raw message/event when available.
+- Profiles must be isolated per workspace so gating sees exactly the active
+  skill set and no user memory/state leaks in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class RunResult:
+    cmd: list[str]
+    exit_code: int | None = None
+    duration_s: float = 0.0
+    stdout_path: str | None = None
+    session_file: str | None = None
+    dry_run: bool = False
+    extra: dict = field(default_factory=dict)
+
+
+@runtime_checkable
+class AgentBackend(Protocol):
+    name: str
+    profile_dir_name: str
+
+    def profile_dir(self, ws: str) -> str: ...
+    def env(self, ws: str) -> dict: ...
+    def bootstrap_profile(self, ws: str, real: str | None = None) -> str: ...
+    def set_active_skills(self, ws: str, include_framework: bool = False) -> None: ...
+    def patch_model(self, ws: str, model: str, provider: str | None = None) -> None: ...
+    def run(self, ws: str, prompt: str, *, tag: str,
+            toolsets: str | None = None, model: str | None = None,
+            max_turns: int = 15, run_budget: int = 300,
+            workdir: str | None = None, include_framework: bool = False,
+            dry_run: bool = False) -> RunResult: ...
+    def export_session(self, ws: str, run_dir: str,
+                       session_id: str | None = None) -> str | None: ...

--- a/wikiskill/backends/claude.py
+++ b/wikiskill/backends/claude.py
@@ -1,0 +1,227 @@
+"""Claude Code agent backend (issue #13).
+
+Runs the loop with Anthropic's Claude Code CLI in print mode (`claude -p`),
+isolated per workspace via CLAUDE_CONFIG_DIR. Skills are symlinked into the
+profile's `.claude/skills/` — the same open SKILL.md format Hermes uses, so
+skills evolved on one backend transfer to the other as-is.
+
+Transcripts come from `--output-format stream-json`: the stream IS the session
+log (every assistant/user event), normalized by backends/transcript.py into
+the Raw Layer shape.
+
+Notes / caveats
+---------------
+- ``patch_model`` is a no-op: Claude selects models via the ``--model`` flag
+  at run time, so there is no profile config to rewrite.
+- ``run_budget`` (Hermes unit, cents-ish) maps to ``--max-budget-usd``
+  (dollars): budget/100, floored at 0.05 (Claude's system-prompt cache floor).
+- The working directory is pinned via ``cwd=`` on the subprocess — Claude Code
+  genuinely operates in its CWD, unlike Hermes' ``--in`` flag (which does not
+  anchor the agent; see docs/RUNS.md bug #1).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+
+from .base import RunResult
+from . import transcript
+
+PROFILE_DIR = ".claude-home"
+FRAMEWORK_SKILLS = ("wikiskill-maintainer", "wikiskill-proposer")
+DEFAULT_TOOLSETS = "terminal,file,code_execution"
+
+# Hermes toolset name -> Claude Code --allowedTools entries
+_TOOLSET_MAP = {
+    "terminal": "Bash",
+    "file": "Read,Write,Edit",
+    "code_execution": "Bash",
+}
+
+
+def _real_config_dir() -> str:
+    return os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude")
+
+
+def profile_dir(ws: str) -> str:
+    return os.path.join(ws, PROFILE_DIR)
+
+
+def env(ws: str) -> dict:
+    e = dict(os.environ)
+    e["CLAUDE_CONFIG_DIR"] = profile_dir(ws)
+    return e
+
+
+def bootstrap_profile(ws: str, real: str | None = None) -> str:
+    """Isolated profile: copy Claude config + credentials, empty skills dir.
+
+    Skills are symlinked per-run by set_active_skills(); the copied credentials
+    (settings.json / .credentials.json / ~/.claude.json) let runs authenticate
+    without touching the user's real config. If the real config dir is missing,
+    the profile still works for runs authenticated via ANTHROPIC_API_KEY.
+    """
+    real = real or _real_config_dir()
+    prof = profile_dir(ws)
+    os.makedirs(os.path.join(prof, "skills"), exist_ok=True)
+    os.makedirs(os.path.join(prof, "projects"), exist_ok=True)
+    for f in ("settings.json", ".credentials.json", ".claude.json"):
+        src = os.path.join(real, f)
+        dst = os.path.join(prof, f)
+        if os.path.exists(src) and not os.path.exists(dst):
+            shutil.copy2(src, dst)
+    return prof
+
+
+def set_active_skills(ws: str, include_framework: bool = False) -> None:
+    """Rebuild the profile's .claude/skills as symlinks of the active set."""
+    prof_skills = os.path.join(profile_dir(ws), "skills")
+    os.makedirs(prof_skills, exist_ok=True)
+    for name in os.listdir(prof_skills):
+        p = os.path.join(prof_skills, name)
+        if os.path.islink(p):
+            os.unlink(p)
+        elif os.path.isdir(p):
+            shutil.rmtree(p)
+    sources = []
+    active = os.path.join(ws, "skills", "active")
+    if os.path.isdir(active):
+        for name in sorted(os.listdir(active)):
+            sources.append(os.path.join(active, name))
+    if include_framework:
+        fw = os.path.join(ws, "skills", "framework")
+        if os.path.isdir(fw):
+            for name in sorted(os.listdir(fw)):
+                sources.append(os.path.join(fw, name))
+    for src in sources:
+        os.symlink(src, os.path.join(prof_skills, os.path.basename(src)))
+
+
+def patch_model(ws: str, model: str, provider: str | None = None) -> None:
+    """Store the model for run-time use (Claude selects models via --model).
+
+    Hermes patches its profile config; claude keeps the pinned model in the
+    isolated profile so `evolve --model` works identically across backends.
+    """
+    os.makedirs(profile_dir(ws), exist_ok=True)
+    with open(os.path.join(profile_dir(ws), "model.txt"), "w", encoding="utf-8") as f:
+        f.write(model)
+
+
+def _resolved_model(ws: str, model: str | None) -> str | None:
+    if model:
+        return model
+    p = os.path.join(profile_dir(ws), "model.txt")
+    if os.path.exists(p):
+        with open(p, encoding="utf-8") as f:
+            m = f.read().strip()
+        if m:
+            return m
+    return None
+
+
+def _allowed_tools(toolsets: str) -> str:
+    seen, parts = set(), []
+    for ts in toolsets.split(","):
+        for t in _TOOLSET_MAP.get(ts.strip(), "").split(","):
+            if t and t not in seen:
+                seen.add(t)
+                parts.append(t)
+    return ",".join(parts)
+
+
+def run(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
+        model: str | None = None, max_turns: int = 15, run_budget: int = 300,
+        workdir: str | None = None, include_framework: bool = False,
+        dry_run: bool = False) -> RunResult:
+    """Run one Claude Code turn (print mode) in the isolated profile."""
+    set_active_skills(ws, include_framework=include_framework)
+    run_dir = os.path.join(ws, "runs", tag)
+    os.makedirs(run_dir, exist_ok=True)
+    qfile = os.path.join(run_dir, "query.txt")
+    with open(qfile, "w", encoding="utf-8") as f:
+        f.write(prompt)
+
+    cmd = ["claude", "-p", "--output-format", "stream-json", "--verbose",
+           "--max-turns", str(max_turns),
+           "--permission-mode", "acceptEdits",
+           "--allowedTools", _allowed_tools(toolsets)]
+    model = _resolved_model(ws, model)
+    if model:
+        cmd += ["--model", model]
+    budget = max(0.05, run_budget / 100.0)
+    cmd += ["--max-budget-usd", f"{budget:.2f}"]
+
+    if dry_run:
+        return RunResult(cmd=cmd, dry_run=True, extra={"run_dir": run_dir,
+                                                       "qfile": qfile})
+
+    cwd = workdir or ws
+    t0 = time.time()
+    out_path = os.path.join(run_dir, "stdout.txt")
+    with open(out_path, "w", encoding="utf-8") as f:
+        p = subprocess.run(cmd, env=env(ws), cwd=cwd, input=prompt,
+                           stdout=f, stderr=subprocess.STDOUT, text=True)
+    dur = round(time.time() - t0, 1)
+    session_file = None
+    if os.path.getsize(out_path) > 0:
+        session_file = transcript.normalize_claude_stream(
+            out_path, os.path.join(run_dir, "session.jsonl"))
+    return RunResult(cmd=cmd, exit_code=p.returncode, duration_s=dur,
+                     stdout_path=out_path, session_file=session_file)
+
+
+def export_session(ws: str, run_dir: str, session_id: str | None = None) -> str | None:
+    """Claude transcripts come from the captured stream; nothing more to do
+    unless stdout.txt exists but session.jsonl wasn't written (edge: dry run
+    or empty output)."""
+    out_path = os.path.join(run_dir, "stdout.txt")
+    dest = os.path.join(run_dir, "session.jsonl")
+    if os.path.exists(out_path):
+        if os.path.getsize(out_path) == 0:
+            # never serve a transcript from an earlier run as this run's result
+            if os.path.exists(dest):
+                os.remove(dest)
+            return None
+        return transcript.normalize_claude_stream(out_path, dest)
+    return dest if os.path.exists(dest) else None
+
+
+class ClaudeBackend:
+    """Protocol-compliant facade over the module-level claude functions."""
+
+    name = "claude"
+    profile_dir_name = PROFILE_DIR
+
+    def profile_dir(self, ws: str) -> str:
+        return profile_dir(ws)
+
+    def env(self, ws: str) -> dict:
+        return env(ws)
+
+    def bootstrap_profile(self, ws: str, real: str | None = None) -> str:
+        return bootstrap_profile(ws, real=real)
+
+    def set_active_skills(self, ws: str, include_framework: bool = False) -> None:
+        return set_active_skills(ws, include_framework=include_framework)
+
+    def patch_model(self, ws: str, model: str, provider: str | None = None) -> None:
+        return patch_model(ws, model, provider)
+
+    def run(self, ws: str, prompt: str, *, tag: str,
+            toolsets: str | None = None, model: str | None = None,
+            max_turns: int = 15, run_budget: int = 300,
+            workdir: str | None = None, include_framework: bool = False,
+            dry_run: bool = False) -> RunResult:
+        return run(ws, prompt, tag=tag,
+                   toolsets=toolsets or DEFAULT_TOOLSETS, model=model,
+                   max_turns=max_turns, run_budget=run_budget,
+                   workdir=workdir, include_framework=include_framework,
+                   dry_run=dry_run)
+
+    def export_session(self, ws: str, run_dir: str,
+                       session_id: str | None = None) -> str | None:
+        return export_session(ws, run_dir, session_id)

--- a/wikiskill/backends/hermes.py
+++ b/wikiskill/backends/hermes.py
@@ -1,0 +1,240 @@
+"""Hermes agent backend — the reference implementation (extracted from the
+original agents.py; behavior preserved so existing workspaces are unaffected).
+
+Faithful gating requires the inference agent to see *exactly* the active skill
+set (paper: S_k). We achieve this with a dedicated HERMES_HOME per evolution
+workspace whose skills/ dir contains only symlinks to the current active skills
+(plus the framework skills when running maintainer/proposer turns). The
+isolated profile has fresh sessions/ and memories/, so inference runs are
+uncontaminated by the user's real profile memory, and every run's full
+trajectory lands in a session JSONL we can copy into the Raw Layer.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import shutil
+import subprocess
+import time
+
+from .base import RunResult
+
+PROFILE_DIR = ".hermes-home"
+FRAMEWORK_SKILLS = ("wikiskill-maintainer", "wikiskill-proposer")
+DEFAULT_TOOLSETS = "terminal,file,code_execution"
+MAINTAINER_TOOLSETS = "file,terminal"
+PROPOSER_TOOLSETS = "file,terminal"
+
+
+def real_home() -> str:
+    return os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
+
+
+def profile_dir(ws: str) -> str:
+    return os.path.join(ws, PROFILE_DIR)
+
+
+def hermes_env(ws: str) -> dict:
+    env = dict(os.environ)
+    env["HERMES_HOME"] = profile_dir(ws)
+    return env
+
+
+def bootstrap_profile(ws: str, real: str | None = None) -> str:
+    """Create the isolated profile: copy secrets/config, empty sessions+memory,
+    opt out of bundled-skill seeding (so the profile's skills/ contains EXACTLY
+    the active skill set — required for faithful gating)."""
+    real = real or real_home()
+    prof = profile_dir(ws)
+    for d in ("sessions", "skills", "memories", "logs"):
+        os.makedirs(os.path.join(prof, d), exist_ok=True)
+    for f in ("config.yaml", ".env", "auth.json"):
+        src = os.path.join(real, f)
+        dst = os.path.join(prof, f)
+        if os.path.exists(src) and not os.path.exists(dst):
+            shutil.copy2(src, dst)
+    # Stop bundled-skill seeding in the isolated profile. Skip silently when the
+    # hermes binary is absent (e.g. CI runs of the test suite).
+    if shutil.which("hermes"):
+        subprocess.run(["hermes", "skills", "opt-out"], env=hermes_env(ws),
+                       capture_output=True, text=True, check=False)
+    return prof
+
+
+def set_active_skills(ws: str, include_framework: bool = False) -> None:
+    """Rebuild the isolated profile's skills/ as symlinks of the active set."""
+    prof_skills = os.path.join(profile_dir(ws), "skills")
+    os.makedirs(prof_skills, exist_ok=True)
+    for name in os.listdir(prof_skills):
+        p = os.path.join(prof_skills, name)
+        if os.path.islink(p):
+            os.unlink(p)
+        elif os.path.isdir(p):
+            shutil.rmtree(p)
+    sources = []
+    active = os.path.join(ws, "skills", "active")
+    if os.path.isdir(active):
+        for name in sorted(os.listdir(active)):
+            sources.append(os.path.join(active, name))
+    if include_framework:
+        fw = os.path.join(ws, "skills", "framework")
+        if os.path.isdir(fw):
+            for name in sorted(os.listdir(fw)):
+                sources.append(os.path.join(fw, name))
+    for src in sources:
+        os.symlink(src, os.path.join(prof_skills, os.path.basename(src)))
+
+
+def newest_session(ws: str) -> str | None:
+    """Deprecated helper — sessions live in state.db now; use export_session()."""
+    sess = os.path.join(profile_dir(ws), "sessions")
+    files = glob.glob(os.path.join(sess, "*.jsonl"))
+    return max(files, key=os.path.getmtime) if files else None
+
+
+def _session_id_from_stdout(stdout_path: str) -> str | None:
+    try:
+        with open(stdout_path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return None
+    m = re.search(r"session_id[:\s]+([0-9a-zA-Z_]+)", text)
+    return m.group(1) if m else None
+
+
+def export_session(ws: str, dest: str, session_id: str | None = None) -> str | None:
+    """Export the isolated profile's latest session to `dest` as JSONL.
+
+    Prefer an explicit session_id (parsed from run stdout); otherwise fall back
+    to the newest session from `hermes sessions list`.
+    """
+    env = hermes_env(ws)
+    if session_id is None:
+        p = subprocess.run(["hermes", "sessions", "list"], env=env,
+                           capture_output=True, text=True)
+        ids = []
+        for line in p.stdout.splitlines():
+            s = line.strip()
+            if s and not s.startswith("Title") and "─" not in s:
+                ids.append(s.split()[-1])
+        if not ids:
+            return None
+        session_id = ids[0]  # list is newest-first
+    assert session_id is not None
+    q = subprocess.run(["hermes", "sessions", "export", "--format", "jsonl",
+                        "--session-id", session_id, dest],
+                       env=env, capture_output=True, text=True)
+    if q.returncode != 0 or not os.path.exists(dest):
+        return None
+    return dest
+
+
+def patch_profile_model(ws: str, model: str, provider: str | None = None) -> None:
+    """Point the isolated profile's default model at `model` (optional provider).
+
+    The `-m` CLI flag fails to resolve models for unconfigured providers (falls
+    through to a broken `moa` fallback). Patching the profile's config.yaml
+    default routes every agent run through the normal default-model path, which
+    works for any provider with creds in the copied .env.
+
+    Also strips the `fallback_providers` block: the default config carries a
+    literal `model: default` placeholder that surfaces as
+    "HTTP 400: default is not a valid model ID" when a request is delegated.
+    """
+    cfg_path = os.path.join(profile_dir(ws), "config.yaml")
+    if not os.path.exists(cfg_path):
+        return
+    with open(cfg_path, encoding="utf-8") as f:
+        lines = f.readlines()
+    out, skip = [], False
+    for i, line in enumerate(lines):
+        if line.startswith("fallback_providers:"):
+            skip = True
+            continue
+        if skip:
+            if line[:2] == "  " or line.strip() == "":
+                continue
+            skip = False
+        if line.startswith("  default:") and "model" in "".join(lines[max(0, i - 2):i]):
+            line = f"  default: {model}\n"
+        elif line.startswith("  provider:") and provider:
+            line = f"  provider: {provider}\n"
+        out.append(line)
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        f.writelines(out)
+
+
+def run(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
+        model: str | None = None, max_turns: int = 15, run_budget: int = 300,
+        workdir: str | None = None, include_framework: bool = False,
+        dry_run: bool = False) -> RunResult:
+    """Run one Hermes agent turn in the isolated profile."""
+    set_active_skills(ws, include_framework=include_framework)
+    run_dir = os.path.join(ws, "runs", tag)
+    os.makedirs(run_dir, exist_ok=True)
+    qfile = os.path.join(run_dir, "query.txt")
+    with open(qfile, "w", encoding="utf-8") as f:
+        f.write(prompt)
+
+    cmd = ["hermes", "chat", "--query-file", qfile, "-Q", "--oneshot",
+           "-t", toolsets, "--max-turns", str(max_turns),
+           "--run-budget", str(run_budget)]
+    if model:
+        cmd += ["-m", model]
+    if workdir:
+        cmd += ["--in", workdir]
+
+    if dry_run:
+        return RunResult(cmd=cmd, dry_run=True, extra={"run_dir": run_dir,
+                                                       "qfile": qfile})
+
+    t0 = time.time()
+    out_path = os.path.join(run_dir, "stdout.txt")
+    with open(out_path, "w", encoding="utf-8") as f:
+        p = subprocess.run(cmd, env=hermes_env(ws), stdout=f,
+                           stderr=subprocess.STDOUT, text=True)
+    dur = round(time.time() - t0, 1)
+    session_file = export_session(ws, os.path.join(run_dir, "session.jsonl"),
+                                  _session_id_from_stdout(out_path))
+    return RunResult(cmd=cmd, exit_code=p.returncode, duration_s=dur,
+                     stdout_path=out_path, session_file=session_file)
+
+
+class HermesBackend:
+    """Protocol-compliant facade over the module-level reference functions."""
+
+    name = "hermes"
+    profile_dir_name = PROFILE_DIR
+
+    def profile_dir(self, ws: str) -> str:
+        return profile_dir(ws)
+
+    def env(self, ws: str) -> dict:
+        return hermes_env(ws)
+
+    def bootstrap_profile(self, ws: str, real: str | None = None) -> str:
+        return bootstrap_profile(ws, real=real)
+
+    def set_active_skills(self, ws: str, include_framework: bool = False) -> None:
+        return set_active_skills(ws, include_framework=include_framework)
+
+    def patch_model(self, ws: str, model: str, provider: str | None = None) -> None:
+        return patch_profile_model(ws, model, provider)
+
+    def run(self, ws: str, prompt: str, *, tag: str,
+            toolsets: str | None = None, model: str | None = None,
+            max_turns: int = 15, run_budget: int = 300,
+            workdir: str | None = None, include_framework: bool = False,
+            dry_run: bool = False) -> RunResult:
+        return run(ws, prompt, tag=tag,
+                   toolsets=toolsets or DEFAULT_TOOLSETS, model=model,
+                   max_turns=max_turns, run_budget=run_budget,
+                   workdir=workdir, include_framework=include_framework,
+                   dry_run=dry_run)
+
+    def export_session(self, ws: str, run_dir: str,
+                       session_id: str | None = None) -> str | None:
+        return export_session(ws, os.path.join(run_dir, "session.jsonl"),
+                              session_id)

--- a/wikiskill/backends/transcript.py
+++ b/wikiskill/backends/transcript.py
@@ -1,0 +1,79 @@
+"""Transcript normalization for the Raw Layer.
+
+Every backend's export_session() must write a NORMALIZED JSONL whose first
+line carries ``tool_call_count`` and ``message_count`` — the gating layer's
+launch-failure check reads exactly those fields (see gating._session_had_no_tool_calls).
+Backends whose native transcripts already match (Hermes) pass through.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+
+
+def tool_call_count(path: str) -> int:
+    """Read tool_call_count from a normalized transcript's first line."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            first = json.loads(f.readline())
+    except (OSError, ValueError):
+        return 0
+    return int(first.get("tool_call_count") or 0)
+
+
+def normalize_hermes(src: str, dest: str) -> str:
+    """Hermes exports already carry tool_call_count on the first line."""
+    shutil.copy2(src, dest)
+    return dest
+
+
+def normalize_claude_stream(src: str, dest: str) -> str:
+    """Convert a `claude -p --output-format stream-json` transcript into the
+    normalized shape: header object + one JSON object per raw event line.
+
+    Counts tool calls from assistant messages' ``content[].type == tool_use``
+    blocks (the stream-json schema for Claude Code v2.x).
+    """
+    tool_calls, messages = 0, 0
+    kept = []
+    with open(src, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except ValueError:
+                continue  # partial/corrupt stream line — keep going
+            if not isinstance(ev, dict):
+                continue  # tolerate non-object JSON events
+            if ev.get("type") == "assistant":
+                messages += 1
+                msg = ev.get("message")
+                for block in (msg.get("content") if isinstance(msg, dict) else []) or []:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        tool_calls += 1
+            elif ev.get("type") == "user":
+                messages += 1
+            elif ev.get("type") == "result":
+                pass  # header carries result metadata below
+            kept.append(ev)
+    header = {
+        "backend": "claude",
+        "tool_call_count": tool_calls,
+        "message_count": messages,
+        "session_id": next((e.get("session_id") for e in kept
+                            if e.get("type") == "result" and e.get("session_id")), None),
+    }
+    with open(dest, "w", encoding="utf-8") as out:
+        out.write(json.dumps(header) + "\n")
+        for ev in kept:
+            out.write(json.dumps(ev) + "\n")
+    return dest
+
+
+def normalize(backend: str, src: str, dest: str) -> str:
+    if backend == "claude":
+        return normalize_claude_stream(src, dest)
+    return normalize_hermes(src, dest)

--- a/wikiskill/cli.py
+++ b/wikiskill/cli.py
@@ -6,7 +6,7 @@ import argparse
 import os
 import sys
 
-from . import agents, bench, compare, gating, harness, tasks as tasks_mod, traces, transfer
+from . import agents, backends, bench, compare, gating, harness, tasks as tasks_mod, traces, transfer
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_WS_ROOT = os.path.join(REPO_ROOT, "workspaces")
@@ -23,6 +23,8 @@ def cmd_init(args) -> int:
     if os.path.exists(ws) and os.listdir(ws):
         print(f"workspace already exists: {ws}")
         return 1
+    if args.backend:
+        backends.write_backend(ws, args.backend)
     harness.init_workspace(ws)
     tasks = bench.generate(args.seed)
     tasks_mod.save(ws, tasks)
@@ -59,7 +61,7 @@ def cmd_status(args) -> int:
     print(f"state: baseline={state.get('baseline')} r_best={state.get('r_best')} "
           f"next_iter={state.get('next_iter')} iters_done={len(state.get('history', []))}")
     print(f"traces: {len(tr)} | active skills: {sorted(active) or ['∅ (S0)']} "
-          f"| wiki patterns: {len(patterns)}")
+          f"| wiki patterns: {len(patterns)} | backend: {agents.resolve(ws).name}")
     for h in state.get("history", []):
         print(f"  iter-{h['iter']:02d}: {h.get('proposal')} R_val={h.get('r_val')} "
               f"{'ACCEPT' if h.get('accepted') else 'reject'}")
@@ -71,6 +73,14 @@ def cmd_evolve(args) -> int:
     if not os.path.exists(tasks_mod.tasks_path(ws)):
         print(f"no workspace at {ws} (run `wikiskill init <domain>`)")
         return 1
+    if args.backend:
+        backends.write_backend(ws, args.backend)
+        print(f"[wikiskill] backend → {args.backend}")
+        if not args.dry_run:
+            # the switched-to backend needs its isolated profile (credentials,
+            # config, skills dir) before any rollout — init created it for
+            # fresh workspaces, but switching an existing one never did.
+            agents.bootstrap_profile(ws)
     state = harness.evolve(ws, iters=args.iters, model=args.model,
                            provider=args.provider, dry_run=args.dry_run,
                            verbose=True, max_turns=args.max_turns,
@@ -182,6 +192,8 @@ def main(argv: list[str] | None = None) -> int:
 
     sp = sub.add_parser("init", help="create a workspace with the demo bench")
     add_ws(sp); sp.add_argument("--seed", type=int, default=42)
+    sp.add_argument("--backend", choices=sorted(backends.BACKENDS), default=None,
+                    help="agent backend for this workspace (default: hermes)")
     sp.set_defaults(fn=cmd_init)
 
     sp = sub.add_parser("bench", help="(re)generate the demo bench")
@@ -198,6 +210,8 @@ def main(argv: list[str] | None = None) -> int:
     sp.add_argument("--model", help="patch the isolated profile's default model "
                                     "(e.g. google/gemini-2.5-flash-lite)")
     sp.add_argument("--provider", help="provider for --model (e.g. openrouter)")
+    sp.add_argument("--backend", choices=sorted(backends.BACKENDS), default=None,
+                    help="switch this workspace's agent backend before evolving")
     sp.add_argument("--max-turns", type=int, default=15,
                     help="per-task inference turn budget (tighter = harder)")
     sp.add_argument("--no-early-stop", action="store_true",

--- a/wikiskill/harness.py
+++ b/wikiskill/harness.py
@@ -20,6 +20,7 @@ import random
 import shutil
 
 from . import agents, gating, prompts, tasks as tasks_mod, traces, wiki
+from .backends.hermes import MAINTAINER_TOOLSETS, PROPOSER_TOOLSETS
 
 FRAMEWORK_SKILLS = ("wikiskill-maintainer", "wikiskill-proposer")
 
@@ -66,7 +67,7 @@ def maintain_step(ws: str, k: int, sampled: list[dict], runner=agents.run_agent,
                   dry_run: bool = False) -> dict:
     prompt = prompts.maintainer_prompt(ws, k, sampled)
     return runner(ws, prompt, tag=f"maintain-{k:02d}",
-                  toolsets=agents.MAINTAINER_TOOLSETS, include_framework=True,
+                  toolsets=MAINTAINER_TOOLSETS, include_framework=True,
                   dry_run=dry_run, max_turns=60, run_budget=1500)
 
 
@@ -74,7 +75,7 @@ def propose_step(ws: str, k: int, train_results: list[dict], runner=agents.run_a
                  dry_run: bool = False) -> tuple[dict | None, dict]:
     prompt = prompts.proposer_prompt(ws, k, train_results)
     res = runner(ws, prompt, tag=f"propose-{k:02d}",
-                 toolsets=agents.PROPOSER_TOOLSETS, include_framework=True,
+                 toolsets=PROPOSER_TOOLSETS, include_framework=True,
                  dry_run=dry_run, max_turns=60, run_budget=1800)
     ppath = os.path.join(ws, "runs", "proposals", f"iter-{k:02d}.json")
     if dry_run or not os.path.exists(ppath):


### PR DESCRIPTION
Replaces the stock mkdocs-material site with a hand-built, animated landing page:

- **Hero**: pulsing arXiv badge, gradient headline, animated 4-stage pipeline (raw experience → persistent wiki → skill proposals → gated rollout) with traveling pulse
- **Stats band**: 5 documented runs · $0.09/iteration · 7 bugs caught · 46 tests · MIT
- **Three layers**: paper's 3-layer design as interactive cards
- **The loop, in action**: click-through stepper replaying the REAL Run-5 numbers (baseline 0.67 → find-secret proposal → R=0.44 → REJECTED)
- **Quickstart**: terminal with live typing animation
- **Trust section**: phantom-grading incident, isolation, paired significance, audit trail
- Zero external deps (no CDNs/fonts/trackers), prefers-reduced-motion respected, visual QA'd via headless Chrome screenshot

Pages workflow now serves `web/` directly (drop-in for the mkdocs build — faster, no pip deps). mkdocs.yml + docs/*.md remain for GitHub-hosted docs.