### PR TITLE
Agent backends: Claude Code alongside Hermes (issue #13) (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ workspaces/demo/
 
 | Command | What it does |
 |---|---|
-| `wikiskill init <domain>` | Create workspace + demo bench |
+| `wikiskill init <domain> [--backend claude]` | Create workspace + demo bench (pins the agent backend) |
 | `wikiskill bench --reset` | Regenerate tasks (deterministic, seed=42) |
 | `wikiskill status` | Workspace state: scores, skills, wiki, history |
 | `wikiskill evolve --iters N [--model M] [--provider P] [--max-turns N] [--no-early-stop]` | The full loop (`--model`/`--provider` patch the isolated profile's default model, e.g. `google/gemini-2.5-flash-lite` + `openrouter`) |
@@ -134,6 +134,20 @@ The gating mechanism has caught both a neutral and a *harmful* proposal live. Fu
 ## How this compares to other community implementations
 
 We audited the three repos that appeared alongside the paper (see [docs/RUNS.md](docs/RUNS.md)). This is the only one that: runs on a real agent stack (Hermes), gates skills through a fully isolated profile, ships verbatim Appendix E prompts, and has a live-verified end-to-end loop (maintainer → proposer → gate → rollback).
+
+## Agent backends
+
+The loop runs on any supported agent CLI — the raw/wiki/skill layers are
+backend-agnostic ([issue #13](https://github.com/ashutoshsinghpr7/wikiskill-hermes/issues/13)).
+
+| Backend | Pin a workspace | Notes |
+|---|---|---|
+| `hermes` (default) | `wikiskill init demo --backend hermes` | reference implementation; isolated `HERMES_HOME` per workspace |
+| `claude` | `wikiskill init demo --backend claude` | Claude Code 2.x (`claude -p`), isolated `CLAUDE_CONFIG_DIR`, transcripts normalized from the stream-json output; `claude auth login` required once |
+
+Each workspace pins its backend in `workspaces/<domain>/workspace.json`; switch
+anytime with `wikiskill evolve <domain> --backend claude`. Skills evolved on
+one backend transfer to another via `wikiskill transfer` (same SKILL.md format).
 
 ## Roadmap
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,292 @@
+"""Backend protocol tests (issue #13): registry, per-backend command
+construction, transcript normalization, and the agents.py facade dispatch."""
+
+import json
+import os
+import subprocess
+
+from wikiskill import agents, backends
+from wikiskill.backends.claude import ClaudeBackend
+from wikiskill.backends.hermes import HermesBackend
+from wikiskill.backends import transcript
+
+
+def _mkws(tmp_path, name="ws") -> str:
+    ws = str(tmp_path / name)
+    os.makedirs(ws, exist_ok=True)
+    return ws
+
+
+# ---------------------------------------------------------------- registry
+
+def test_default_backend_is_hermes_for_legacy_workspaces(tmp_path):
+    ws = _mkws(tmp_path)
+    assert backends.read_backend(ws) == "hermes"
+    assert backends.resolve(ws).name == "hermes"
+    assert not os.path.exists(backends.workspace_file(ws))  # nothing written
+
+
+def test_write_and_resolve_backend(tmp_path):
+    ws = _mkws(tmp_path)
+    backends.write_backend(ws, "claude")
+    assert backends.read_backend(ws) == "claude"
+    assert backends.resolve(ws).name == "claude"
+    assert backends.workspace_file(ws).endswith("workspace.json")
+    try:
+        backends.write_backend(ws, "nope")
+        assert False, "unknown backend must raise"
+    except ValueError:
+        pass
+
+
+def test_write_backend_creates_missing_workspace_dir(tmp_path):
+    """Regression: `wikiskill init --backend claude` writes workspace.json
+    before init_workspace creates the dir — must not crash."""
+    fresh = str(tmp_path / "not" / "created" / "yet")
+    backends.write_backend(fresh, "claude")
+    assert os.path.exists(backends.workspace_file(fresh))
+
+
+def test_resolve_unknown_backend_raises_valueerror_not_keyerror(tmp_path):
+    """Regression: a hand-edited workspace.json with a bogus backend must
+    fail loudly (ValueError), not with an uncaught KeyError."""
+    ws = _mkws(tmp_path)
+    with open(backends.workspace_file(ws), "w", encoding="utf-8") as f:
+        json.dump({"backend": "evil"}, f)
+    try:
+        backends.resolve(ws)
+        assert False, "must raise"
+    except ValueError as e:
+        assert "evil" in str(e)
+
+
+def test_read_backend_tolerates_non_dict_json(tmp_path):
+    """Regression (adversarial review): valid JSON of the wrong type in
+    workspace.json (null/[]/true/42/\"x\") must fall back to hermes, not crash
+    with AttributeError on `.get`."""
+    ws = _mkws(tmp_path)
+    for payload in ("null", "[]", "true", "42", '"claude"'):
+        with open(backends.workspace_file(ws), "w", encoding="utf-8") as f:
+            f.write(payload)
+        assert backends.read_backend(ws) == "hermes", payload
+        assert backends.resolve(ws).name == "hermes", payload
+
+
+# ---------------------------------------------------------------- hermes
+
+def test_hermes_backend_dry_run_command(tmp_path):
+    res = HermesBackend().run(_mkws(tmp_path), "hi", tag="t1", dry_run=True,
+                              model="x/y", workdir="/sandbox", max_turns=8)
+    assert res.dry_run and res.cmd[0] == "hermes"
+    for flag in ("--query-file", "-Q", "--oneshot", "-t", "--max-turns",
+                 "--run-budget", "-m", "--in"):
+        assert flag in res.cmd
+    assert res.cmd[res.cmd.index("--max-turns") + 1] == "8"
+    assert res.cmd[res.cmd.index("-m") + 1] == "x/y"
+    assert res.cmd[res.cmd.index("--in") + 1] == "/sandbox"
+
+
+# ---------------------------------------------------------------- claude
+
+def test_claude_backend_dry_run_command(tmp_path):
+    res = ClaudeBackend().run(_mkws(tmp_path), "hi", tag="t1", dry_run=True,
+                              model="sonnet", workdir="/sandbox", max_turns=8)
+    assert res.dry_run and res.cmd[0] == "claude"
+    for flag in ("-p", "--output-format", "stream-json", "--verbose",
+                 "--max-turns", "--permission-mode", "acceptEdits",
+                 "--allowedTools", "--model", "--max-budget-usd"):
+        assert flag in res.cmd, flag
+    assert res.cmd[res.cmd.index("--max-turns") + 1] == "8"
+    assert res.cmd[res.cmd.index("--model") + 1] == "sonnet"
+    # terminal,file,code_execution -> Bash,Read,Write,Edit (deduped)
+    tools = res.cmd[res.cmd.index("--allowedTools") + 1]
+    assert tools == "Bash,Read,Write,Edit"
+    # run_budget 300 (hermes cents-ish) -> $3.00 max-budget-usd
+    assert res.cmd[res.cmd.index("--max-budget-usd") + 1] == "3.00"
+
+
+def test_claude_patch_model_flows_into_run(tmp_path):
+    """Regression: `evolve --backend claude --model X` must reach the CLI —
+    the stored model is applied when the runner gets no explicit model."""
+    ws = _mkws(tmp_path)
+    ClaudeBackend().patch_model(ws, "claude-3-5-sonnet", "anthropic")
+    res = ClaudeBackend().run(ws, "hi", tag="t1", dry_run=True)
+    assert res.cmd[res.cmd.index("--model") + 1] == "claude-3-5-sonnet"
+    # explicit --model at run time wins over the stored one
+    res2 = ClaudeBackend().run(ws, "hi", tag="t2", dry_run=True, model="other")
+    assert res2.cmd[res2.cmd.index("--model") + 1] == "other"
+    # nothing stored -> no --model flag at all
+    ws2 = _mkws(tmp_path, "ws2")
+    res3 = ClaudeBackend().run(ws2, "hi", tag="t3", dry_run=True)
+    assert "--model" not in res3.cmd
+
+
+def test_claude_run_uses_isolated_config_and_pins_cwd(tmp_path, monkeypatch):
+    ws = _mkws(tmp_path)
+    calls = {}
+
+    def fake_run(cmd, **kw):
+        calls["cmd"] = cmd
+        calls["env"] = kw.get("env")
+        calls["cwd"] = kw.get("cwd")
+        calls["input"] = kw.get("input")
+        # emulate a tiny stream-json transcript: one user, one assistant w/ tool_use
+        out = "\n".join([
+            json.dumps({"type": "user", "message": {"role": "user"}}),
+            json.dumps({"type": "assistant", "message": {
+                "content": [{"type": "tool_use", "name": "Bash", "id": "t1"},
+                            {"type": "text", "text": "done"}]}}),
+            json.dumps({"type": "result", "subtype": "success",
+                        "session_id": "abc123", "num_turns": 2}),
+        ])
+        open(kw["stdout"].name, "w", encoding="utf-8").write(out)
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    res = ClaudeBackend().run(ws, "the prompt", tag="t1", workdir="/sandbox")
+    assert calls["env"]["CLAUDE_CONFIG_DIR"] == os.path.join(ws, ".claude-home")
+    assert calls["cwd"] == "/sandbox"
+    assert calls["input"] == "the prompt"
+    # transcript normalized with tool_call_count for the gating check
+    assert res.session_file and os.path.exists(res.session_file)
+    header = json.loads(open(res.session_file, encoding="utf-8").readline())
+    assert header["tool_call_count"] == 1
+    assert header["message_count"] == 2
+    assert header["session_id"] == "abc123"
+
+
+def test_claude_bootstrap_copies_config(tmp_path):
+    real = tmp_path / "real-claude"
+    real.mkdir()
+    (real / "settings.json").write_text("{}")
+    (real / ".credentials.json").write_text("{}")
+    ws = _mkws(tmp_path)
+    ClaudeBackend().bootstrap_profile(ws, real=str(real))
+    prof = os.path.join(ws, ".claude-home")
+    assert os.path.exists(os.path.join(prof, "settings.json"))
+    assert os.path.exists(os.path.join(prof, ".credentials.json"))
+    assert os.path.isdir(os.path.join(prof, "skills"))
+    assert os.path.isdir(os.path.join(prof, "projects"))
+
+
+# ---------------------------------------------------------------- transcript
+
+def test_normalize_claude_stream_counts_tool_calls(tmp_path):
+    src = tmp_path / "raw.jsonl"
+    raw = [
+        {"type": "user", "message": {"role": "user"}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "thinking"},
+            {"type": "tool_use", "name": "Read", "id": "r1"}]}},
+        {"type": "user", "message": {"role": "user"}},
+        {"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "name": "Bash", "id": "b1"},
+            {"type": "tool_use", "name": "Edit", "id": "e1"}]}},
+        {"type": "result", "session_id": "sess-9"},
+        "garbage line that is not json",
+    ]
+    src.write_text("\n".join(json.dumps(x) for x in raw))
+    dest = str(tmp_path / "session.jsonl")
+    transcript.normalize_claude_stream(str(src), dest)
+    lines = open(dest, encoding="utf-8").read().splitlines()
+    header = json.loads(lines[0])
+    assert header["tool_call_count"] == 3
+    assert header["message_count"] == 4
+    assert header["session_id"] == "sess-9"
+    # raw events preserved after the header; corrupt line skipped
+    assert len(lines) == 6  # header + 5 events (garbage dropped)
+
+
+def test_normalized_claude_transcript_fed_to_gating_check(tmp_path):
+    from wikiskill import gating
+    src = tmp_path / "raw.jsonl"
+    src.write_text("\n".join([
+        json.dumps({"type": "user", "message": {"role": "user"}}),
+        json.dumps({"type": "assistant", "message": {"content": [
+            {"type": "text", "text": "no tools"}]}}),
+    ]))
+    dest = str(tmp_path / "session.jsonl")
+    transcript.normalize_claude_stream(str(src), dest)
+    assert gating._session_had_no_tool_calls(dest) is True  # launch failure
+    src2 = tmp_path / "raw2.jsonl"
+    src2.write_text("\n".join([
+        json.dumps({"type": "user", "message": {"role": "user"}}),
+        json.dumps({"type": "assistant", "message": {"content": [
+            {"type": "tool_use", "name": "Bash", "id": "b"}]}}),
+    ]))
+    dest2 = str(tmp_path / "session2.jsonl")
+    transcript.normalize_claude_stream(str(src2), dest2)
+    assert gating._session_had_no_tool_calls(dest2) is False
+
+
+# ---------------------------------------------------------------- facade
+
+def test_facade_dispatches_to_workspace_backend(tmp_path):
+    ws = _mkws(tmp_path)
+    res = agents.run_agent(ws, "hi", tag="t1", dry_run=True)
+    assert res["cmd"][0] == "hermes"  # legacy default
+    backends.write_backend(ws, "claude")
+    res = agents.run_agent(ws, "hi", tag="t1", dry_run=True)
+    assert res["cmd"][0] == "claude"
+    assert res["dry_run"] is True and "cmd" in res
+
+
+def test_facade_run_agent_dict_shape_matches_gating_contract(tmp_path):
+    ws = _mkws(tmp_path)
+    res = agents.run_agent(ws, "hi", tag="t1", dry_run=True)
+    for key in ("cmd", "exit_code", "duration_s", "stdout_path", "session_file"):
+        assert key in res
+
+
+def test_evolve_switch_backend_bootstraps_profile(tmp_path, monkeypatch):
+    """Regression (adversarial review): `evolve --backend claude` on an
+    existing workspace must bootstrap the claude profile (credentials,
+    config, skills dir) — otherwise every rollout fails auth and scores 0.0."""
+    from wikiskill import cli, harness, tasks as tasks_mod
+    from wikiskill import bench as bench_mod
+    ws = _mkws(tmp_path)
+    harness.init_workspace(ws)
+    tasks_mod.save(ws, bench_mod.generate(42))
+    calls = []
+    monkeypatch.setattr(cli.agents, "bootstrap_profile",
+                        lambda *a, **k: calls.append("boot"))
+    monkeypatch.setattr(cli.harness, "evolve",
+                        lambda *a, **k: {"baseline": 1.0, "r_best": 1.0})
+    rc = cli.main(["evolve", "dummy", "--ws", ws, "--backend", "claude", "--dry-run"])
+    assert rc == 0 and calls == [], "dry-run must not bootstrap (side effects)"
+    rc = cli.main(["evolve", "dummy", "--ws", ws, "--backend", "claude"])
+    assert rc == 0 and calls == ["boot"], "real evolve must bootstrap the profile"
+
+
+def test_normalize_tolerates_non_dict_message(tmp_path):
+    """Regression: a stream event whose `message` is a string (corrupt/
+    partial JSON) must not crash the parser."""
+    src = tmp_path / "raw.jsonl"
+    src.write_text("\n".join([
+        json.dumps({"type": "assistant", "message": "interrupted"}),
+        json.dumps({"type": "user", "message": {"role": "user"}}),
+        json.dumps({"type": "result", "session_id": "s1"}),
+    ]))
+    dest = str(tmp_path / "session.jsonl")
+    transcript.normalize_claude_stream(str(src), dest)
+    header = json.loads(open(dest, encoding="utf-8").readline())
+    assert header["tool_call_count"] == 0
+    # the corrupted assistant event still counts as a message (content is
+    # unparseable but the event itself is real) — no crash is the point
+    assert header["message_count"] == 2
+
+
+def test_claude_export_never_serves_stale_transcript(tmp_path):
+    """Regression: an empty stdout (agent launch failure) must return None and
+    REMOVE any session.jsonl left by an earlier run — gating must never grade
+    a stale transcript as this run's result."""
+    from wikiskill.backends.claude import export_session
+    run_dir = str(tmp_path / "runs" / "iter-00" / "val" / "t1")
+    os.makedirs(run_dir)
+    dest = os.path.join(run_dir, "session.jsonl")
+    with open(dest, "w", encoding="utf-8") as f:
+        f.write('{"tool_call_count": 3}\n')
+    with open(os.path.join(run_dir, "stdout.txt"), "w", encoding="utf-8"):
+        pass  # empty stream
+    assert export_session(str(tmp_path), run_dir) is None
+    assert not os.path.exists(dest), "stale transcript must be removed"

--- a/wikiskill/agents.py
+++ b/wikiskill/agents.py
@@ -1,201 +1,46 @@
-"""Agent runner: executes Hermes agent turns in an isolated profile.
+"""Agent runner facade (issue #13).
 
-Faithful gating requires the inference agent to see *exactly* the active skill
-set (paper: S_k). We achieve this with a dedicated HERMES_HOME per evolution
-workspace whose skills/ dir contains only symlinks to the current active skills
-(plus the framework skills when running maintainer/proposer turns). The
-isolated profile has fresh sessions/ and memories/, so inference runs are
-uncontaminated by the user's real profile memory, and every run's full
-trajectory lands in a session JSONL we can copy into the Raw Layer.
+Pre-backend API kept intact so harness/gating/cli/tests are untouched: every
+function here used to live in this module and now dispatches to the workspace's
+pinned backend (see wikiskill.backends). Workspaces without a workspace.json
+resolve to Hermes — identical behavior to before this refactor.
+
+The module-level Hermes helpers are re-exported for backward compatibility and
+for tests that assert on hermes-specific behavior.
 """
 
 from __future__ import annotations
 
-import glob
-import os
-import shutil
-import subprocess
-import time
-
-PROFILE_DIR = ".hermes-home"
-FRAMEWORK_SKILLS = ("wikiskill-maintainer", "wikiskill-proposer")
-DEFAULT_TOOLSETS = "terminal,file,code_execution"
-MAINTAINER_TOOLSETS = "file,terminal"
-PROPOSER_TOOLSETS = "file,terminal"
-
-
-def real_home() -> str:
-    return os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
-
-
-def profile_dir(ws: str) -> str:
-    return os.path.join(ws, PROFILE_DIR)
-
-
-def hermes_env(ws: str) -> dict:
-    env = dict(os.environ)
-    env["HERMES_HOME"] = profile_dir(ws)
-    return env
+from .backends import resolve
 
 
 def bootstrap_profile(ws: str, real: str | None = None) -> str:
-    """Create the isolated profile: copy secrets/config, empty sessions+memory,
-    opt out of bundled-skill seeding (so the profile's skills/ contains EXACTLY
-    the active skill set — required for faithful gating)."""
-    real = real or real_home()
-    prof = profile_dir(ws)
-    for d in ("sessions", "skills", "memories", "logs"):
-        os.makedirs(os.path.join(prof, d), exist_ok=True)
-    for f in ("config.yaml", ".env", "auth.json"):
-        src = os.path.join(real, f)
-        dst = os.path.join(prof, f)
-        if os.path.exists(src) and not os.path.exists(dst):
-            shutil.copy2(src, dst)
-    # Stop bundled-skill seeding in the isolated profile. Skip silently when the
-    # hermes binary is absent (e.g. CI runs of the test suite).
-    if shutil.which("hermes"):
-        subprocess.run(["hermes", "skills", "opt-out"], env=hermes_env(ws),
-                       capture_output=True, text=True, check=False)
-    return prof
+    """Isolated profile for the workspace's backend (config + creds copy)."""
+    return resolve(ws).bootstrap_profile(ws, real=real)
 
 
 def set_active_skills(ws: str, include_framework: bool = False) -> None:
-    """Rebuild the isolated profile's skills/ as symlinks of the active set."""
-    prof_skills = os.path.join(profile_dir(ws), "skills")
-    os.makedirs(prof_skills, exist_ok=True)
-    for name in os.listdir(prof_skills):
-        p = os.path.join(prof_skills, name)
-        if os.path.islink(p):
-            os.unlink(p)
-        elif os.path.isdir(p):
-            shutil.rmtree(p)
-    sources = []
-    active = os.path.join(ws, "skills", "active")
-    if os.path.isdir(active):
-        for name in sorted(os.listdir(active)):
-            sources.append(os.path.join(active, name))
-    if include_framework:
-        fw = os.path.join(ws, "skills", "framework")
-        if os.path.isdir(fw):
-            for name in sorted(os.listdir(fw)):
-                sources.append(os.path.join(fw, name))
-    for src in sources:
-        os.symlink(src, os.path.join(prof_skills, os.path.basename(src)))
-
-
-def newest_session(ws: str) -> str | None:
-    """Deprecated helper — sessions live in state.db now; use export_session()."""
-    sess = os.path.join(profile_dir(ws), "sessions")
-    files = glob.glob(os.path.join(sess, "*.jsonl"))
-    return max(files, key=os.path.getmtime) if files else None
-
-
-def export_session(ws: str, dest: str, session_id: str | None = None) -> str | None:
-    """Export the isolated profile's latest session to `dest` as JSONL.
-
-    Prefer an explicit session_id (parsed from run stdout); otherwise fall back
-    to the newest session from `hermes sessions list`.
-    """
-    env = hermes_env(ws)
-    if session_id is None:
-        p = subprocess.run(["hermes", "sessions", "list"], env=env,
-                           capture_output=True, text=True)
-        ids = []
-        for line in p.stdout.splitlines():
-            s = line.strip()
-            if s and not s.startswith("Title") and "─" not in s:
-                ids.append(s.split()[-1])
-        if not ids:
-            return None
-        session_id = ids[0]  # list is newest-first
-    assert session_id is not None
-    q = subprocess.run(["hermes", "sessions", "export", "--format", "jsonl",
-                        "--session-id", session_id, dest],
-                       env=env, capture_output=True, text=True)
-    if q.returncode != 0 or not os.path.exists(dest):
-        return None
-    return dest
-
-
-def _session_id_from_stdout(stdout_path: str) -> str | None:
-    try:
-        with open(stdout_path, encoding="utf-8", errors="replace") as f:
-            text = f.read()
-    except OSError:
-        return None
-    import re
-
-    m = re.search(r"session_id[:\s]+([0-9a-zA-Z_]+)", text)
-    return m.group(1) if m else None
+    """Rebuild the isolated profile's skills as symlinks of the active set."""
+    resolve(ws).set_active_skills(ws, include_framework=include_framework)
 
 
 def patch_profile_model(ws: str, model: str, provider: str | None = None) -> None:
-    """Point the isolated profile's default model at `model` (optional provider).
-
-    The `-m` CLI flag fails to resolve models for unconfigured providers (falls
-    through to a broken `moa` fallback). Patching the profile's config.yaml
-    default routes every agent run through the normal default-model path, which
-    works for any provider with creds in the copied .env.
-
-    Also strips the `fallback_providers` block: the default config carries a
-    literal `model: default` placeholder that surfaces as
-    "HTTP 400: default is not a valid model ID" when a request is delegated.
-    """
-    cfg_path = os.path.join(profile_dir(ws), "config.yaml")
-    if not os.path.exists(cfg_path):
-        return
-    with open(cfg_path, encoding="utf-8") as f:
-        lines = f.readlines()
-    out, skip = [], False
-    for i, line in enumerate(lines):
-        if line.startswith("fallback_providers:"):
-            skip = True
-            continue
-        if skip:
-            if line[:2] == "  " or line.strip() == "":
-                continue
-            skip = False
-        if line.startswith("  default:") and "model" in "".join(lines[max(0, i - 2):i]):
-            line = f"  default: {model}\n"
-        elif line.startswith("  provider:") and provider:
-            line = f"  provider: {provider}\n"
-        out.append(line)
-    with open(cfg_path, "w", encoding="utf-8") as f:
-        f.writelines(out)
+    """Point the workspace's backend at `model` (Hermes: config patch; Claude: no-op)."""
+    resolve(ws).patch_model(ws, model, provider)
 
 
-def run_agent(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
+def run_agent(ws: str, prompt: str, *, tag: str, toolsets: str | None = None,
               model: str | None = None, max_turns: int = 15, run_budget: int = 300,
               workdir: str | None = None, include_framework: bool = False,
               dry_run: bool = False) -> dict:
-    """Run one Hermes agent turn in the isolated profile. Returns a result dict
-    with cmd/exit_code/duration/stdout_path/session_file. With dry_run=True it
-    returns the constructed command without executing anything."""
-    set_active_skills(ws, include_framework=include_framework)
-    run_dir = os.path.join(ws, "runs", tag)
-    os.makedirs(run_dir, exist_ok=True)
-    qfile = os.path.join(run_dir, "query.txt")
-    with open(qfile, "w", encoding="utf-8") as f:
-        f.write(prompt)
-
-    cmd = ["hermes", "chat", "--query-file", qfile, "-Q", "--oneshot",
-           "-t", toolsets, "--max-turns", str(max_turns),
-           "--run-budget", str(run_budget)]
-    if model:
-        cmd += ["-m", model]
-    if workdir:
-        cmd += ["--in", workdir]
-
-    if dry_run:
-        return {"cmd": cmd, "run_dir": run_dir, "qfile": qfile, "dry_run": True}
-
-    t0 = time.time()
-    out_path = os.path.join(run_dir, "stdout.txt")
-    with open(out_path, "w", encoding="utf-8") as f:
-        p = subprocess.run(cmd, env=hermes_env(ws), stdout=f,
-                           stderr=subprocess.STDOUT, text=True)
-    dur = round(time.time() - t0, 1)
-    session_file = export_session(ws, os.path.join(run_dir, "session.jsonl"),
-                                  _session_id_from_stdout(out_path))
-    return {"cmd": cmd, "exit_code": p.returncode, "duration_s": dur,
-            "stdout_path": out_path, "session_file": session_file}
+    """Run one agent turn on the workspace's backend. Returns the legacy dict
+    shape consumed by gating.run_task (cmd/exit_code/duration_s/stdout_path/
+    session_file + dry-run extras)."""
+    res = resolve(ws).run(ws, prompt, tag=tag, toolsets=toolsets, model=model,
+                          max_turns=max_turns, run_budget=run_budget,
+                          workdir=workdir, include_framework=include_framework,
+                          dry_run=dry_run)
+    return {"cmd": res.cmd, "exit_code": res.exit_code,
+            "duration_s": res.duration_s, "stdout_path": res.stdout_path,
+            "session_file": res.session_file, "dry_run": res.dry_run,
+            **res.extra}

--- a/wikiskill/backends/__init__.py
+++ b/wikiskill/backends/__init__.py
@@ -1,0 +1,55 @@
+"""Agent backend registry (issue #13).
+``wikiskill init --backend`` / ``wikiskill evolve --backend``). Workspaces
+created before backends existed have no such file and resolve to Hermes —
+full backward compatibility.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+from .base import AgentBackend
+from .claude import ClaudeBackend
+from .hermes import HermesBackend
+
+BACKENDS: dict[str, AgentBackend] = {
+    "hermes": HermesBackend(),
+    "claude": ClaudeBackend(),
+}
+DEFAULT_BACKEND = "hermes"
+
+
+def workspace_file(ws: str) -> str:
+    return os.path.join(ws, "workspace.json")
+
+
+def read_backend(ws: str) -> str:
+    try:
+        with open(workspace_file(ws), encoding="utf-8") as f:
+            d = json.load(f)
+    except (OSError, ValueError):
+        return DEFAULT_BACKEND
+    # tolerate valid-but-wrong-type JSON (null/[]/42/"x") — corrupt configs
+    # fall back, they never crash the loop
+    return d.get("backend", DEFAULT_BACKEND) if isinstance(d, dict) else DEFAULT_BACKEND
+
+
+def write_backend(ws: str, name: str) -> None:
+    if name not in BACKENDS:
+        raise ValueError(f"unknown backend {name!r}; available: {sorted(BACKENDS)}")
+    os.makedirs(ws, exist_ok=True)  # fresh `init` workspaces don't exist yet
+    with open(workspace_file(ws), "w", encoding="utf-8") as f:
+        json.dump({"backend": name}, f, indent=2)
+
+
+def get_backend(name: str) -> AgentBackend:
+    if name not in BACKENDS:
+        raise ValueError(f"unknown backend {name!r}; available: {sorted(BACKENDS)}")
+    return BACKENDS[name]
+
+
+def resolve(ws: str) -> AgentBackend:
+    # get_backend (not raw dict access) so a hand-edited workspace.json
+    # raises a clear ValueError instead of a KeyError
+    return get_backend(read_backend(ws))

--- a/wikiskill/backends/base.py
+++ b/wikiskill/backends/base.py
@@ -1,0 +1,52 @@
+"""Agent backend protocol (issue #13).
+
+The whole Algorithm-1 loop is agent-agnostic: it talks to an AgentBackend for
+exactly five operations. Hermes is the reference backend; Claude Code ships in
+this PR; Codex and OpenCode are follow-ups.
+
+Contract notes
+--------------
+- ``run()`` must return a ``RunResult`` even on failure (exit_code != 0).
+- ``run(dry_run=True)`` must return the constructed argv without executing.
+- ``export_session()`` must write a NORMALIZED transcript: a JSONL file whose
+  first line is an object carrying ``tool_call_count`` and ``message_count``
+  (the gating layer's launch-failure check reads exactly those two fields),
+  followed by one JSON object per raw message/event when available.
+- Profiles must be isolated per workspace so gating sees exactly the active
+  skill set and no user memory/state leaks in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol, runtime_checkable
+
+
+@dataclass
+class RunResult:
+    cmd: list[str]
+    exit_code: int | None = None
+    duration_s: float = 0.0
+    stdout_path: str | None = None
+    session_file: str | None = None
+    dry_run: bool = False
+    extra: dict = field(default_factory=dict)
+
+
+@runtime_checkable
+class AgentBackend(Protocol):
+    name: str
+    profile_dir_name: str
+
+    def profile_dir(self, ws: str) -> str: ...
+    def env(self, ws: str) -> dict: ...
+    def bootstrap_profile(self, ws: str, real: str | None = None) -> str: ...
+    def set_active_skills(self, ws: str, include_framework: bool = False) -> None: ...
+    def patch_model(self, ws: str, model: str, provider: str | None = None) -> None: ...
+    def run(self, ws: str, prompt: str, *, tag: str,
+            toolsets: str | None = None, model: str | None = None,
+            max_turns: int = 15, run_budget: int = 300,
+            workdir: str | None = None, include_framework: bool = False,
+            dry_run: bool = False) -> RunResult: ...
+    def export_session(self, ws: str, run_dir: str,
+                       session_id: str | None = None) -> str | None: ...

--- a/wikiskill/backends/claude.py
+++ b/wikiskill/backends/claude.py
@@ -1,0 +1,227 @@
+"""Claude Code agent backend (issue #13).
+
+Runs the loop with Anthropic's Claude Code CLI in print mode (`claude -p`),
+isolated per workspace via CLAUDE_CONFIG_DIR. Skills are symlinked into the
+profile's `.claude/skills/` — the same open SKILL.md format Hermes uses, so
+skills evolved on one backend transfer to the other as-is.
+
+Transcripts come from `--output-format stream-json`: the stream IS the session
+log (every assistant/user event), normalized by backends/transcript.py into
+the Raw Layer shape.
+
+Notes / caveats
+---------------
+- ``patch_model`` is a no-op: Claude selects models via the ``--model`` flag
+  at run time, so there is no profile config to rewrite.
+- ``run_budget`` (Hermes unit, cents-ish) maps to ``--max-budget-usd``
+  (dollars): budget/100, floored at 0.05 (Claude's system-prompt cache floor).
+- The working directory is pinned via ``cwd=`` on the subprocess — Claude Code
+  genuinely operates in its CWD, unlike Hermes' ``--in`` flag (which does not
+  anchor the agent; see docs/RUNS.md bug #1).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import time
+
+from .base import RunResult
+from . import transcript
+
+PROFILE_DIR = ".claude-home"
+FRAMEWORK_SKILLS = ("wikiskill-maintainer", "wikiskill-proposer")
+DEFAULT_TOOLSETS = "terminal,file,code_execution"
+
+# Hermes toolset name -> Claude Code --allowedTools entries
+_TOOLSET_MAP = {
+    "terminal": "Bash",
+    "file": "Read,Write,Edit",
+    "code_execution": "Bash",
+}
+
+
+def _real_config_dir() -> str:
+    return os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude")
+
+
+def profile_dir(ws: str) -> str:
+    return os.path.join(ws, PROFILE_DIR)
+
+
+def env(ws: str) -> dict:
+    e = dict(os.environ)
+    e["CLAUDE_CONFIG_DIR"] = profile_dir(ws)
+    return e
+
+
+def bootstrap_profile(ws: str, real: str | None = None) -> str:
+    """Isolated profile: copy Claude config + credentials, empty skills dir.
+
+    Skills are symlinked per-run by set_active_skills(); the copied credentials
+    (settings.json / .credentials.json / ~/.claude.json) let runs authenticate
+    without touching the user's real config. If the real config dir is missing,
+    the profile still works for runs authenticated via ANTHROPIC_API_KEY.
+    """
+    real = real or _real_config_dir()
+    prof = profile_dir(ws)
+    os.makedirs(os.path.join(prof, "skills"), exist_ok=True)
+    os.makedirs(os.path.join(prof, "projects"), exist_ok=True)
+    for f in ("settings.json", ".credentials.json", ".claude.json"):
+        src = os.path.join(real, f)
+        dst = os.path.join(prof, f)
+        if os.path.exists(src) and not os.path.exists(dst):
+            shutil.copy2(src, dst)
+    return prof
+
+
+def set_active_skills(ws: str, include_framework: bool = False) -> None:
+    """Rebuild the profile's .claude/skills as symlinks of the active set."""
+    prof_skills = os.path.join(profile_dir(ws), "skills")
+    os.makedirs(prof_skills, exist_ok=True)
+    for name in os.listdir(prof_skills):
+        p = os.path.join(prof_skills, name)
+        if os.path.islink(p):
+            os.unlink(p)
+        elif os.path.isdir(p):
+            shutil.rmtree(p)
+    sources = []
+    active = os.path.join(ws, "skills", "active")
+    if os.path.isdir(active):
+        for name in sorted(os.listdir(active)):
+            sources.append(os.path.join(active, name))
+    if include_framework:
+        fw = os.path.join(ws, "skills", "framework")
+        if os.path.isdir(fw):
+            for name in sorted(os.listdir(fw)):
+                sources.append(os.path.join(fw, name))
+    for src in sources:
+        os.symlink(src, os.path.join(prof_skills, os.path.basename(src)))
+
+
+def patch_model(ws: str, model: str, provider: str | None = None) -> None:
+    """Store the model for run-time use (Claude selects models via --model).
+
+    Hermes patches its profile config; claude keeps the pinned model in the
+    isolated profile so `evolve --model` works identically across backends.
+    """
+    os.makedirs(profile_dir(ws), exist_ok=True)
+    with open(os.path.join(profile_dir(ws), "model.txt"), "w", encoding="utf-8") as f:
+        f.write(model)
+
+
+def _resolved_model(ws: str, model: str | None) -> str | None:
+    if model:
+        return model
+    p = os.path.join(profile_dir(ws), "model.txt")
+    if os.path.exists(p):
+        with open(p, encoding="utf-8") as f:
+            m = f.read().strip()
+        if m:
+            return m
+    return None
+
+
+def _allowed_tools(toolsets: str) -> str:
+    seen, parts = set(), []
+    for ts in toolsets.split(","):
+        for t in _TOOLSET_MAP.get(ts.strip(), "").split(","):
+            if t and t not in seen:
+                seen.add(t)
+                parts.append(t)
+    return ",".join(parts)
+
+
+def run(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
+        model: str | None = None, max_turns: int = 15, run_budget: int = 300,
+        workdir: str | None = None, include_framework: bool = False,
+        dry_run: bool = False) -> RunResult:
+    """Run one Claude Code turn (print mode) in the isolated profile."""
+    set_active_skills(ws, include_framework=include_framework)
+    run_dir = os.path.join(ws, "runs", tag)
+    os.makedirs(run_dir, exist_ok=True)
+    qfile = os.path.join(run_dir, "query.txt")
+    with open(qfile, "w", encoding="utf-8") as f:
+        f.write(prompt)
+
+    cmd = ["claude", "-p", "--output-format", "stream-json", "--verbose",
+           "--max-turns", str(max_turns),
+           "--permission-mode", "acceptEdits",
+           "--allowedTools", _allowed_tools(toolsets)]
+    model = _resolved_model(ws, model)
+    if model:
+        cmd += ["--model", model]
+    budget = max(0.05, run_budget / 100.0)
+    cmd += ["--max-budget-usd", f"{budget:.2f}"]
+
+    if dry_run:
+        return RunResult(cmd=cmd, dry_run=True, extra={"run_dir": run_dir,
+                                                       "qfile": qfile})
+
+    cwd = workdir or ws
+    t0 = time.time()
+    out_path = os.path.join(run_dir, "stdout.txt")
+    with open(out_path, "w", encoding="utf-8") as f:
+        p = subprocess.run(cmd, env=env(ws), cwd=cwd, input=prompt,
+                           stdout=f, stderr=subprocess.STDOUT, text=True)
+    dur = round(time.time() - t0, 1)
+    session_file = None
+    if os.path.getsize(out_path) > 0:
+        session_file = transcript.normalize_claude_stream(
+            out_path, os.path.join(run_dir, "session.jsonl"))
+    return RunResult(cmd=cmd, exit_code=p.returncode, duration_s=dur,
+                     stdout_path=out_path, session_file=session_file)
+
+
+def export_session(ws: str, run_dir: str, session_id: str | None = None) -> str | None:
+    """Claude transcripts come from the captured stream; nothing more to do
+    unless stdout.txt exists but session.jsonl wasn't written (edge: dry run
+    or empty output)."""
+    out_path = os.path.join(run_dir, "stdout.txt")
+    dest = os.path.join(run_dir, "session.jsonl")
+    if os.path.exists(out_path):
+        if os.path.getsize(out_path) == 0:
+            # never serve a transcript from an earlier run as this run's result
+            if os.path.exists(dest):
+                os.remove(dest)
+            return None
+        return transcript.normalize_claude_stream(out_path, dest)
+    return dest if os.path.exists(dest) else None
+
+
+class ClaudeBackend:
+    """Protocol-compliant facade over the module-level claude functions."""
+
+    name = "claude"
+    profile_dir_name = PROFILE_DIR
+
+    def profile_dir(self, ws: str) -> str:
+        return profile_dir(ws)
+
+    def env(self, ws: str) -> dict:
+        return env(ws)
+
+    def bootstrap_profile(self, ws: str, real: str | None = None) -> str:
+        return bootstrap_profile(ws, real=real)
+
+    def set_active_skills(self, ws: str, include_framework: bool = False) -> None:
+        return set_active_skills(ws, include_framework=include_framework)
+
+    def patch_model(self, ws: str, model: str, provider: str | None = None) -> None:
+        return patch_model(ws, model, provider)
+
+    def run(self, ws: str, prompt: str, *, tag: str,
+            toolsets: str | None = None, model: str | None = None,
+            max_turns: int = 15, run_budget: int = 300,
+            workdir: str | None = None, include_framework: bool = False,
+            dry_run: bool = False) -> RunResult:
+        return run(ws, prompt, tag=tag,
+                   toolsets=toolsets or DEFAULT_TOOLSETS, model=model,
+                   max_turns=max_turns, run_budget=run_budget,
+                   workdir=workdir, include_framework=include_framework,
+                   dry_run=dry_run)
+
+    def export_session(self, ws: str, run_dir: str,
+                       session_id: str | None = None) -> str | None:
+        return export_session(ws, run_dir, session_id)

--- a/wikiskill/backends/hermes.py
+++ b/wikiskill/backends/hermes.py
@@ -1,0 +1,240 @@
+"""Hermes agent backend — the reference implementation (extracted from the
+original agents.py; behavior preserved so existing workspaces are unaffected).
+
+Faithful gating requires the inference agent to see *exactly* the active skill
+set (paper: S_k). We achieve this with a dedicated HERMES_HOME per evolution
+workspace whose skills/ dir contains only symlinks to the current active skills
+(plus the framework skills when running maintainer/proposer turns). The
+isolated profile has fresh sessions/ and memories/, so inference runs are
+uncontaminated by the user's real profile memory, and every run's full
+trajectory lands in a session JSONL we can copy into the Raw Layer.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import shutil
+import subprocess
+import time
+
+from .base import RunResult
+
+PROFILE_DIR = ".hermes-home"
+FRAMEWORK_SKILLS = ("wikiskill-maintainer", "wikiskill-proposer")
+DEFAULT_TOOLSETS = "terminal,file,code_execution"
+MAINTAINER_TOOLSETS = "file,terminal"
+PROPOSER_TOOLSETS = "file,terminal"
+
+
+def real_home() -> str:
+    return os.environ.get("HERMES_HOME") or os.path.expanduser("~/.hermes")
+
+
+def profile_dir(ws: str) -> str:
+    return os.path.join(ws, PROFILE_DIR)
+
+
+def hermes_env(ws: str) -> dict:
+    env = dict(os.environ)
+    env["HERMES_HOME"] = profile_dir(ws)
+    return env
+
+
+def bootstrap_profile(ws: str, real: str | None = None) -> str:
+    """Create the isolated profile: copy secrets/config, empty sessions+memory,
+    opt out of bundled-skill seeding (so the profile's skills/ contains EXACTLY
+    the active skill set — required for faithful gating)."""
+    real = real or real_home()
+    prof = profile_dir(ws)
+    for d in ("sessions", "skills", "memories", "logs"):
+        os.makedirs(os.path.join(prof, d), exist_ok=True)
+    for f in ("config.yaml", ".env", "auth.json"):
+        src = os.path.join(real, f)
+        dst = os.path.join(prof, f)
+        if os.path.exists(src) and not os.path.exists(dst):
+            shutil.copy2(src, dst)
+    # Stop bundled-skill seeding in the isolated profile. Skip silently when the
+    # hermes binary is absent (e.g. CI runs of the test suite).
+    if shutil.which("hermes"):
+        subprocess.run(["hermes", "skills", "opt-out"], env=hermes_env(ws),
+                       capture_output=True, text=True, check=False)
+    return prof
+
+
+def set_active_skills(ws: str, include_framework: bool = False) -> None:
+    """Rebuild the isolated profile's skills/ as symlinks of the active set."""
+    prof_skills = os.path.join(profile_dir(ws), "skills")
+    os.makedirs(prof_skills, exist_ok=True)
+    for name in os.listdir(prof_skills):
+        p = os.path.join(prof_skills, name)
+        if os.path.islink(p):
+            os.unlink(p)
+        elif os.path.isdir(p):
+            shutil.rmtree(p)
+    sources = []
+    active = os.path.join(ws, "skills", "active")
+    if os.path.isdir(active):
+        for name in sorted(os.listdir(active)):
+            sources.append(os.path.join(active, name))
+    if include_framework:
+        fw = os.path.join(ws, "skills", "framework")
+        if os.path.isdir(fw):
+            for name in sorted(os.listdir(fw)):
+                sources.append(os.path.join(fw, name))
+    for src in sources:
+        os.symlink(src, os.path.join(prof_skills, os.path.basename(src)))
+
+
+def newest_session(ws: str) -> str | None:
+    """Deprecated helper — sessions live in state.db now; use export_session()."""
+    sess = os.path.join(profile_dir(ws), "sessions")
+    files = glob.glob(os.path.join(sess, "*.jsonl"))
+    return max(files, key=os.path.getmtime) if files else None
+
+
+def _session_id_from_stdout(stdout_path: str) -> str | None:
+    try:
+        with open(stdout_path, encoding="utf-8", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return None
+    m = re.search(r"session_id[:\s]+([0-9a-zA-Z_]+)", text)
+    return m.group(1) if m else None
+
+
+def export_session(ws: str, dest: str, session_id: str | None = None) -> str | None:
+    """Export the isolated profile's latest session to `dest` as JSONL.
+
+    Prefer an explicit session_id (parsed from run stdout); otherwise fall back
+    to the newest session from `hermes sessions list`.
+    """
+    env = hermes_env(ws)
+    if session_id is None:
+        p = subprocess.run(["hermes", "sessions", "list"], env=env,
+                           capture_output=True, text=True)
+        ids = []
+        for line in p.stdout.splitlines():
+            s = line.strip()
+            if s and not s.startswith("Title") and "─" not in s:
+                ids.append(s.split()[-1])
+        if not ids:
+            return None
+        session_id = ids[0]  # list is newest-first
+    assert session_id is not None
+    q = subprocess.run(["hermes", "sessions", "export", "--format", "jsonl",
+                        "--session-id", session_id, dest],
+                       env=env, capture_output=True, text=True)
+    if q.returncode != 0 or not os.path.exists(dest):
+        return None
+    return dest
+
+
+def patch_profile_model(ws: str, model: str, provider: str | None = None) -> None:
+    """Point the isolated profile's default model at `model` (optional provider).
+
+    The `-m` CLI flag fails to resolve models for unconfigured providers (falls
+    through to a broken `moa` fallback). Patching the profile's config.yaml
+    default routes every agent run through the normal default-model path, which
+    works for any provider with creds in the copied .env.
+
+    Also strips the `fallback_providers` block: the default config carries a
+    literal `model: default` placeholder that surfaces as
+    "HTTP 400: default is not a valid model ID" when a request is delegated.
+    """
+    cfg_path = os.path.join(profile_dir(ws), "config.yaml")
+    if not os.path.exists(cfg_path):
+        return
+    with open(cfg_path, encoding="utf-8") as f:
+        lines = f.readlines()
+    out, skip = [], False
+    for i, line in enumerate(lines):
+        if line.startswith("fallback_providers:"):
+            skip = True
+            continue
+        if skip:
+            if line[:2] == "  " or line.strip() == "":
+                continue
+            skip = False
+        if line.startswith("  default:") and "model" in "".join(lines[max(0, i - 2):i]):
+            line = f"  default: {model}\n"
+        elif line.startswith("  provider:") and provider:
+            line = f"  provider: {provider}\n"
+        out.append(line)
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        f.writelines(out)
+
+
+def run(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
+        model: str | None = None, max_turns: int = 15, run_budget: int = 300,
+        workdir: str | None = None, include_framework: bool = False,
+        dry_run: bool = False) -> RunResult:
+    """Run one Hermes agent turn in the isolated profile."""
+    set_active_skills(ws, include_framework=include_framework)
+    run_dir = os.path.join(ws, "runs", tag)
+    os.makedirs(run_dir, exist_ok=True)
+    qfile = os.path.join(run_dir, "query.txt")
+    with open(qfile, "w", encoding="utf-8") as f:
+        f.write(prompt)
+
+    cmd = ["hermes", "chat", "--query-file", qfile, "-Q", "--oneshot",
+           "-t", toolsets, "--max-turns", str(max_turns),
+           "--run-budget", str(run_budget)]
+    if model:
+        cmd += ["-m", model]
+    if workdir:
+        cmd += ["--in", workdir]
+
+    if dry_run:
+        return RunResult(cmd=cmd, dry_run=True, extra={"run_dir": run_dir,
+                                                       "qfile": qfile})
+
+    t0 = time.time()
+    out_path = os.path.join(run_dir, "stdout.txt")
+    with open(out_path, "w", encoding="utf-8") as f:
+        p = subprocess.run(cmd, env=hermes_env(ws), stdout=f,
+                           stderr=subprocess.STDOUT, text=True)
+    dur = round(time.time() - t0, 1)
+    session_file = export_session(ws, os.path.join(run_dir, "session.jsonl"),
+                                  _session_id_from_stdout(out_path))
+    return RunResult(cmd=cmd, exit_code=p.returncode, duration_s=dur,
+                     stdout_path=out_path, session_file=session_file)
+
+
+class HermesBackend:
+    """Protocol-compliant facade over the module-level reference functions."""
+
+    name = "hermes"
+    profile_dir_name = PROFILE_DIR
+
+    def profile_dir(self, ws: str) -> str:
+        return profile_dir(ws)
+
+    def env(self, ws: str) -> dict:
+        return hermes_env(ws)
+
+    def bootstrap_profile(self, ws: str, real: str | None = None) -> str:
+        return bootstrap_profile(ws, real=real)
+
+    def set_active_skills(self, ws: str, include_framework: bool = False) -> None:
+        return set_active_skills(ws, include_framework=include_framework)
+
+    def patch_model(self, ws: str, model: str, provider: str | None = None) -> None:
+        return patch_profile_model(ws, model, provider)
+
+    def run(self, ws: str, prompt: str, *, tag: str,
+            toolsets: str | None = None, model: str | None = None,
+            max_turns: int = 15, run_budget: int = 300,
+            workdir: str | None = None, include_framework: bool = False,
+            dry_run: bool = False) -> RunResult:
+        return run(ws, prompt, tag=tag,
+                   toolsets=toolsets or DEFAULT_TOOLSETS, model=model,
+                   max_turns=max_turns, run_budget=run_budget,
+                   workdir=workdir, include_framework=include_framework,
+                   dry_run=dry_run)
+
+    def export_session(self, ws: str, run_dir: str,
+                       session_id: str | None = None) -> str | None:
+        return export_session(ws, os.path.join(run_dir, "session.jsonl"),
+                              session_id)

--- a/wikiskill/backends/transcript.py
+++ b/wikiskill/backends/transcript.py
@@ -1,0 +1,79 @@
+"""Transcript normalization for the Raw Layer.
+
+Every backend's export_session() must write a NORMALIZED JSONL whose first
+line carries ``tool_call_count`` and ``message_count`` — the gating layer's
+launch-failure check reads exactly those fields (see gating._session_had_no_tool_calls).
+Backends whose native transcripts already match (Hermes) pass through.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+
+
+def tool_call_count(path: str) -> int:
+    """Read tool_call_count from a normalized transcript's first line."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            first = json.loads(f.readline())
+    except (OSError, ValueError):
+        return 0
+    return int(first.get("tool_call_count") or 0)
+
+
+def normalize_hermes(src: str, dest: str) -> str:
+    """Hermes exports already carry tool_call_count on the first line."""
+    shutil.copy2(src, dest)
+    return dest
+
+
+def normalize_claude_stream(src: str, dest: str) -> str:
+    """Convert a `claude -p --output-format stream-json` transcript into the
+    normalized shape: header object + one JSON object per raw event line.
+
+    Counts tool calls from assistant messages' ``content[].type == tool_use``
+    blocks (the stream-json schema for Claude Code v2.x).
+    """
+    tool_calls, messages = 0, 0
+    kept = []
+    with open(src, encoding="utf-8", errors="replace") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                ev = json.loads(line)
+            except ValueError:
+                continue  # partial/corrupt stream line — keep going
+            if not isinstance(ev, dict):
+                continue  # tolerate non-object JSON events
+            if ev.get("type") == "assistant":
+                messages += 1
+                msg = ev.get("message")
+                for block in (msg.get("content") if isinstance(msg, dict) else []) or []:
+                    if isinstance(block, dict) and block.get("type") == "tool_use":
+                        tool_calls += 1
+            elif ev.get("type") == "user":
+                messages += 1
+            elif ev.get("type") == "result":
+                pass  # header carries result metadata below
+            kept.append(ev)
+    header = {
+        "backend": "claude",
+        "tool_call_count": tool_calls,
+        "message_count": messages,
+        "session_id": next((e.get("session_id") for e in kept
+                            if e.get("type") == "result" and e.get("session_id")), None),
+    }
+    with open(dest, "w", encoding="utf-8") as out:
+        out.write(json.dumps(header) + "\n")
+        for ev in kept:
+            out.write(json.dumps(ev) + "\n")
+    return dest
+
+
+def normalize(backend: str, src: str, dest: str) -> str:
+    if backend == "claude":
+        return normalize_claude_stream(src, dest)
+    return normalize_hermes(src, dest)

--- a/wikiskill/cli.py
+++ b/wikiskill/cli.py
@@ -6,7 +6,7 @@ import argparse
 import os
 import sys
 
-from . import agents, bench, compare, gating, harness, tasks as tasks_mod, traces, transfer
+from . import agents, backends, bench, compare, gating, harness, tasks as tasks_mod, traces, transfer
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 DEFAULT_WS_ROOT = os.path.join(REPO_ROOT, "workspaces")
@@ -23,6 +23,8 @@ def cmd_init(args) -> int:
     if os.path.exists(ws) and os.listdir(ws):
         print(f"workspace already exists: {ws}")
         return 1
+    if args.backend:
+        backends.write_backend(ws, args.backend)
     harness.init_workspace(ws)
     tasks = bench.generate(args.seed)
     tasks_mod.save(ws, tasks)
@@ -59,7 +61,7 @@ def cmd_status(args) -> int:
     print(f"state: baseline={state.get('baseline')} r_best={state.get('r_best')} "
           f"next_iter={state.get('next_iter')} iters_done={len(state.get('history', []))}")
     print(f"traces: {len(tr)} | active skills: {sorted(active) or ['∅ (S0)']} "
-          f"| wiki patterns: {len(patterns)}")
+          f"| wiki patterns: {len(patterns)} | backend: {agents.resolve(ws).name}")
     for h in state.get("history", []):
         print(f"  iter-{h['iter']:02d}: {h.get('proposal')} R_val={h.get('r_val')} "
               f"{'ACCEPT' if h.get('accepted') else 'reject'}")
@@ -71,6 +73,14 @@ def cmd_evolve(args) -> int:
     if not os.path.exists(tasks_mod.tasks_path(ws)):
         print(f"no workspace at {ws} (run `wikiskill init <domain>`)")
         return 1
+    if args.backend:
+        backends.write_backend(ws, args.backend)
+        print(f"[wikiskill] backend → {args.backend}")
+        if not args.dry_run:
+            # the switched-to backend needs its isolated profile (credentials,
+            # config, skills dir) before any rollout — init created it for
+            # fresh workspaces, but switching an existing one never did.
+            agents.bootstrap_profile(ws)
     state = harness.evolve(ws, iters=args.iters, model=args.model,
                            provider=args.provider, dry_run=args.dry_run,
                            verbose=True, max_turns=args.max_turns,
@@ -182,6 +192,8 @@ def main(argv: list[str] | None = None) -> int:
 
     sp = sub.add_parser("init", help="create a workspace with the demo bench")
     add_ws(sp); sp.add_argument("--seed", type=int, default=42)
+    sp.add_argument("--backend", choices=sorted(backends.BACKENDS), default=None,
+                    help="agent backend for this workspace (default: hermes)")
     sp.set_defaults(fn=cmd_init)
 
     sp = sub.add_parser("bench", help="(re)generate the demo bench")
@@ -198,6 +210,8 @@ def main(argv: list[str] | None = None) -> int:
     sp.add_argument("--model", help="patch the isolated profile's default model "
                                     "(e.g. google/gemini-2.5-flash-lite)")
     sp.add_argument("--provider", help="provider for --model (e.g. openrouter)")
+    sp.add_argument("--backend", choices=sorted(backends.BACKENDS), default=None,
+                    help="switch this workspace's agent backend before evolving")
     sp.add_argument("--max-turns", type=int, default=15,
                     help="per-task inference turn budget (tighter = harder)")
     sp.add_argument("--no-early-stop", action="store_true",

--- a/wikiskill/harness.py
+++ b/wikiskill/harness.py
@@ -20,6 +20,7 @@ import random
 import shutil
 
 from . import agents, gating, prompts, tasks as tasks_mod, traces, wiki
+from .backends.hermes import MAINTAINER_TOOLSETS, PROPOSER_TOOLSETS
 
 FRAMEWORK_SKILLS = ("wikiskill-maintainer", "wikiskill-proposer")
 
@@ -66,7 +67,7 @@ def maintain_step(ws: str, k: int, sampled: list[dict], runner=agents.run_agent,
                   dry_run: bool = False) -> dict:
     prompt = prompts.maintainer_prompt(ws, k, sampled)
     return runner(ws, prompt, tag=f"maintain-{k:02d}",
-                  toolsets=agents.MAINTAINER_TOOLSETS, include_framework=True,
+                  toolsets=MAINTAINER_TOOLSETS, include_framework=True,
                   dry_run=dry_run, max_turns=60, run_budget=1500)
 
 
@@ -74,7 +75,7 @@ def propose_step(ws: str, k: int, train_results: list[dict], runner=agents.run_a
                  dry_run: bool = False) -> tuple[dict | None, dict]:
     prompt = prompts.proposer_prompt(ws, k, train_results)
     res = runner(ws, prompt, tag=f"propose-{k:02d}",
-                 toolsets=agents.PROPOSER_TOOLSETS, include_framework=True,
+                 toolsets=PROPOSER_TOOLSETS, include_framework=True,
                  dry_run=dry_run, max_turns=60, run_budget=1800)
     ppath = os.path.join(ws, "runs", "proposals", f"iter-{k:02d}.json")
     if dry_run or not os.path.exists(ppath):


### PR DESCRIPTION
* backends: agent backend protocol (issue #13) — Hermes extracted as reference backend, Claude Code adapter, transcript normalizer, --backend pinning, facade shim keeping pre-backend API

* docs: fix typo in backends section

* fix(backends): 4 adversarial-review findings — init --backend crash on fresh ws, resolve KeyError on bad workspace.json, transcript crash on non-dict message, stale-transcript serving in claude export_session; regression tests for each

* fix(backends): evolve --model now flows to claude (stored model applied at run time; explicit model wins)

* fix(backends): adversarial-review findings — evolve --backend bootstraps the switched-to profile (auth otherwise fails silently); read_backend tolerates valid-JSON-wrong-type; regression tests for both

* test: fix evolve-switch-backend test to use --ws (positional domain resolves under workspaces/)

* test: evolve-switch-backend regression needs a real workspace (tasks.json present)

---------