### PR TITLE
feat/version 011

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,11 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # OIDC for PyPI trusted publishing (no API token needed)
 
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
-    env:
-      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -27,8 +26,8 @@ jobs:
         with:
           generate_release_notes: true
           files: dist/*
-      - name: Publish to PyPI (when PYPI_TOKEN is configured)
-        if: env.PYPI_TOKEN != ''
+      - name: Publish to PyPI (trusted publishing)
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ env.PYPI_TOKEN }}
+        # no `password` — the action exchanges the OIDC id-token for a
+        # short-lived PyPI token. Requires the publisher registered on PyPI:
+        # owner ashutoshsinghpr7 / repo wikiskill-hermes / workflow release.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wikiskill-hermes"
-version = "0.1.0"
+version = "0.1.1"
 description = "WikiSkill (arXiv:2608.27454) for Hermes Agent — self-evolving agent skills via a persistent knowledge wiki"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/wikiskill/__init__.py
+++ b/wikiskill/__init__.py
@@ -5,4 +5,4 @@ real Hermes agent runs in an isolated profile (HERMES_HOME) so skill-set
 gating is faithful to the paper's Algorithm 1.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
- **release: PyPI trusted publishing (OIDC) — id-token: write, no API-token secret, publish step unconditioned on tags**
- **chore: bump to 0.1.1 (aligned with tag v0.1.1)**
