### PR TITLE
fix(compare): stop forwarding max_turns to gating.run_task (TypeError on every real run)

### DIFF
--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -87,3 +87,24 @@ def test_report_contains_verdict_and_table():
     }
     out = compare.format_report(rep)
     assert "t1" in out and "A better" in out and "p=0.25" in out
+
+
+def test_compare_default_runner_does_not_crash(tmp_path):
+    """Regression: run_comparison forwarded max_turns to gating.run_task,
+    which has no such parameter — the default CLI path (no --max-turns)
+    crashed with TypeError on every real run."""
+    ws_a = build_ws(str(tmp_path / "a-ws"))
+    ws_b = build_ws(str(tmp_path / "b-ws"))
+    rep = compare.run_comparison(ws_a, ws_b, iters=1, dry_run=True)
+    # dry runs produce score=None; they count as failures, not crashes
+    assert rep["pass_rate"]["A"] == rep["pass_rate"]["B"] == 0.0
+
+
+def test_compare_no_val_tasks_is_a_clean_error(tmp_path):
+    ws = build_ws(str(tmp_path / "a-ws"))
+    tasks = tasks_mod.load(ws)
+    for t in tasks:
+        t["split"] = "train"
+    tasks_mod.save(ws, tasks)
+    with pytest.raises(ValueError, match="no val tasks"):
+        compare.run_comparison(ws, ws, iters=1, dry_run=True)

--- a/wikiskill/compare.py
+++ b/wikiskill/compare.py
@@ -15,12 +15,15 @@ Verdict semantics:
 from __future__ import annotations
 
 import math
+import os
 
-from . import gating, tasks as tasks_mod
+from . import agents, gating, tasks as tasks_mod, traces as traces_mod
 
 
-def _pass(score: float) -> bool:
-    return score >= 0.5  # all bundled graders return 0.0 or 1.0
+def _pass(score: float | None) -> bool:
+    # Dry runs and agent launch failures produce score=None; count them as
+    # failures instead of crashing (missing deliverables already grade 0.0).
+    return score is not None and score >= 0.5  # all bundled graders return 0.0 or 1.0
 
 
 def _two_sided_binomial_p(b: int, c: int) -> float:
@@ -37,6 +40,27 @@ def _two_sided_binomial_p(b: int, c: int) -> float:
     return min(p, 1.0)
 
 
+def _runner_with_turns(runner, max_turns: int | None):
+    """Return a run_task-compatible runner with the agent turn budget pinned.
+
+    gating.run_task (the default runner) has no max_turns parameter — the turn
+    budget belongs to the agent-call layer (see cli.cmd_run_task, which wraps
+    agents.run_agent for exactly this reason). Forwarding max_turns to
+    run_task raises TypeError; wrap the agent call instead.
+    """
+    if max_turns is None:
+        return runner
+
+    def wrapped(ws, task, k, **kw):
+        def agent(*a, **ak):
+            ak.setdefault("max_turns", max_turns)
+            return agents.run_agent(*a, **ak)
+
+        return runner(ws, task, k, runner=agent, **kw)
+
+    return wrapped
+
+
 def run_comparison(ws_a: str, ws_b: str, iters: int = 3, *,
                    runner=gating.run_task, dry_run: bool = False,
                    max_turns: int | None = None) -> dict:
@@ -49,17 +73,37 @@ def run_comparison(ws_a: str, ws_b: str, iters: int = 3, *,
         raise ValueError(
             f"workspaces have different val task sets "
             f"(A has {len(ids_a)}, B has {len(ids_b)}); compare needs identical tasks")
+    if not ids_a:
+        raise ValueError(
+            "no val tasks in either workspace; nothing to compare "
+            "(regenerate the bench so at least one task has split=\"val\")")
     ids = sorted(ids_a)
 
+    # Fairness advisory: a paired comparison is only meaningful when both
+    # workspaces' past val traces were produced against the same evolution
+    # state. If a workspace already has val traces from several iterations,
+    # per-task pass rates below may mix different skill sets.
+    for tag, ws in (("A", ws_a), ("B", ws_b)):
+        seen: dict[str, set[int]] = {}
+        for tr in traces_mod.list_traces(ws, split="val"):
+            seen.setdefault(tr["task_id"], set()).add(tr["it"])
+        drifted = {tid: sorted(its) for tid, its in seen.items() if len(its) > 1}
+        if drifted:
+            print(f"[wikiskill] ⚠ workspace {tag} "
+                  f"({os.path.basename(ws.rstrip('/'))}): some val tasks have "
+                  f"traces from multiple iterations {drifted}; pass rates may "
+                  f"mix different skill sets")
+
     # Per (task, run) outcome for each workspace.
+    effective_runner = _runner_with_turns(runner, max_turns)
     scores = {"A": {}, "B": {}}
     for tag, ws in (("A", ws_a), ("B", ws_b)):
         for tid in ids:
             task = next(t for t in (ta if tag == "A" else tb) if t["id"] == tid)
             per_run = []
             for k in range(iters):
-                res = runner(ws, task, k, dry_run=dry_run,
-                             overwrite=True, max_turns=max_turns)
+                res = effective_runner(ws, task, k, dry_run=dry_run,
+                                       overwrite=True)
                 per_run.append(1.0 if _pass(res["score"]) else 0.0)
             scores[tag][tid] = per_run
 


### PR DESCRIPTION
## What happens

`wikiskill compare A B` (default path, no `--max-turns`) crashes before running any task:

```
TypeError: run_task() got an unexpected keyword argument 'max_turns'
```

`run_comparison()` forwards `max_turns` to `gating.run_task`, which has no such
parameter. The CLI's own `run-task` command wraps `agents.run_agent` to set
`max_turns` (see `cli.cmd_run_task`); `compare.py` needs the same treatment.
The bundled tests miss this because every test injects a fake runner that
accepts `**kw`.

Two smaller issues hit on the same real path:
- a workspace whose `tasks.json` has no `val` split crashes with
  `ZeroDivisionError` (empty rows) — now a clean `ValueError`
- a dry-run / launch-failed rollout has `score=None`; `_pass(None)` raised
  `TypeError` — now counted as a non-pass

## The fix

- `_runner_with_turns()`: when `max_turns` is set, wrap the default runner so
  the turn budget is pinned at the agent-call layer (`runner=agents.run_agent`
  with `max_turns`), mirroring `cmd_run_task`. `gating.run_task` is unchanged.
- `_pass(None)` → False
- clean `ValueError` for empty val sets
- fairness advisory printed when a workspace's val traces span multiple
  iterations (per-task pass rates may mix different skill sets)

## Verification (Python 3.14 venv)

- `pytest tests/test_compare.py` → **7 passed**, incl. the 2 new regression
  tests (default-runner crash + empty-val error)
- `pyflakes wikiskill/ tests/` → clean
- full suite: `pytest tests/ -q` → **43 passed / 5 failed (48 total)**. The 5
  failures are **pre-existing on `main`** (confirmed on a clean `main` worktree:
  identical 5 failed) and unrelated to this change — two `code_stdout` grader
  tests need `python3` on PATH, and three `test_harness` tests read a UTF-8
  file with Windows' default `gbk` codec. None touch `compare.py`; CI on a
  POSIX runner should report 48 passed.

A ready-to-apply patch is attached
(`git am 0001-*.patch` or `git apply`).
