### PR TITLE
feat(backends): Codex + GitHub Copilot CLI backends (closes #15, #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > 📚 **Docs site**: [ashutoshsinghpr7.github.io/wikiskill](https://ashutoshsinghpr7.github.io/wikiskill) · **arXiv**: [2608.27454](https://arxiv.org/abs/2608.27454)
 
-A faithful, production-minded implementation of **[WikiSkill: Compiling Agent Experience into Persistent Knowledge for Skill Evolution](https://arxiv.org/abs/2608.27454)** (arXiv:2608.27454, Google Research). The loop is **agent-agnostic** — **Hermes Agent** is the reference backend (built natively), **Claude Code** ships in the box, and Codex/OpenCode are on the roadmap ([issue #13](https://github.com/ashutoshsinghpr7/wikiskill/issues/13)). Your agent becomes both the *student* and the *teacher*.
+A faithful, production-minded implementation of **[WikiSkill: Compiling Agent Experience into Persistent Knowledge for Skill Evolution](https://arxiv.org/abs/2608.27454)** (arXiv:2608.27454, Google Research). The loop is **agent-agnostic** — **Hermes Agent** is the reference backend (built natively), **Claude Code**, **Codex** and **GitHub Copilot CLI** ship in the box, and OpenCode is on the roadmap ([issue #13](https://github.com/ashutoshsinghpr7/wikiskill/issues/13)). Your agent becomes both the *student* and the *teacher*.
 
 [![Python](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
@@ -148,6 +148,8 @@ backend-agnostic ([issue #13](https://github.com/ashutoshsinghpr7/wikiskill/issu
 |---|---|---|
 | `hermes` (default) | `wikiskill init demo --backend hermes` | reference implementation; isolated `HERMES_HOME` per workspace |
 | `claude` | `wikiskill init demo --backend claude` | Claude Code 2.x (`claude -p`), isolated `CLAUDE_CONFIG_DIR`, transcripts normalized from the stream-json output; `claude auth login` required once |
+| `codex` | `wikiskill init demo --backend codex` | OpenAI Codex (`codex exec --json --full-auto`), isolated `CODEX_HOME`, transcripts from session JSONL; `codex login` once + binary on PATH |
+| `copilot` | `wikiskill init demo --backend copilot` | GitHub Copilot CLI (`copilot -p -s`), isolated `COPILOT_HOME`, skills symlinked into the sandbox's `.github/skills/`; `copilot login` once (or `GH_TOKEN`) |
 
 Each workspace pins its backend in `workspaces/<domain>/workspace.json`; switch
 anytime with `wikiskill evolve <domain> --backend claude`. Skills evolved on
@@ -187,13 +189,13 @@ gate-approved skills. All ship as standard SKILL.md (agentskills.io-compatible).
 - [x] `compare` command — paired exact-binomial run comparison ([#6](https://github.com/ashutoshsinghpr7/wikiskill/pull/6))
 - [x] Skill *transfer* across workspaces/models ([#7](https://github.com/ashutoshsinghpr7/wikiskill/pull/7))
 - [x] Cron-driven overnight evolution (`hermes cron`, 01:00 IST nightly) + docs/CRON.md
-- [x] Multi-agent backends: Hermes (reference) + **Claude Code**, protocol ready for more ([#13](https://github.com/ashutoshsinghpr7/wikiskill/issues/13))
+- [x] Multi-agent backends: Hermes (reference) + **Claude Code**, **Codex**, **GitHub Copilot CLI** ([#13](https://github.com/ashutoshsinghpr7/wikiskill/issues/13), [#15](https://github.com/ashutoshsinghpr7/wikiskill/issues/15), [#24](https://github.com/ashutoshsinghpr7/wikiskill/issues/24))
 - [x] GitHub Pages — custom animated docs site ([#18](https://github.com/ashutoshsinghpr7/wikiskill/pull/18))
 - [x] PyPI package `wikiskill` via **tokenless trusted publishing** ([#20](https://github.com/ashutoshsinghpr7/wikiskill/pull/20))
 - [x] Multi-iteration compounding run — honest negative documented (Run 6)
 
 **Planned:**
-- [ ] Codex backend ([#15](https://github.com/ashutoshsinghpr7/wikiskill/issues/15))
+- [ ] Codex backend — **done** ([#15](https://github.com/ashutoshsinghpr7/wikiskill/issues/15))
 - [ ] OpenCode backend ([#16](https://github.com/ashutoshsinghpr7/wikiskill/issues/16))
 - [ ] Cross-agent transfer demo — evolve on one agent, gate on another ([#17](https://github.com/ashutoshsinghpr7/wikiskill/issues/17))
 - [ ] A live *acceptance* gate (proposal beats baseline on a real model) — still the open scientific question (see Run 6)

--- a/docs/RUNS.md
+++ b/docs/RUNS.md
@@ -168,3 +168,41 @@ Audited 2026-08-30 (all three appeared within 2 days of the paper):
 Independent design convergence: SkillForge and this repo both chose strict
 `>` gating, wiki-always-persists, and fake-runner loop tests — good evidence
 both read Algorithm 1 correctly.
+
+## Backend live verification (2026-09-02, issue #13/#15/#24)
+
+Real runs of the new backends against their actual CLIs — every claim below
+was produced by executing the shipped command, not mocks:
+
+### Copilot backend (issue #24) — live-verified twice
+
+| Run | Result |
+|---|---|
+| Smoke 1 (PONG task, 44s) | exit 0, deliverable written, transcript captured |
+| Smoke 2 (PONG task, 29s) | exit 0, **tool_call_count=9 / message_count=8** (real activity) |
+
+Live findings that shaped the code:
+- Copilot's `events.jsonl` schema is `session.start / user.message /
+  assistant.message / tool.execution_start / tool.execution_complete / ...`
+  — an initial parser keyed on `message` events produced `tool_call_count=0`
+  for real runs, which the gating launch-failure check would have read as a
+  launch failure (scored from fresh sandbox). Fixed + re-verified live.
+- `-p -s --allow-all-tools --allow-all-paths --no-ask-user` is the valid
+  non-interactive shape; skills load from the run context's `.github/skills/`
+  (`--add-dir`), so the active set is symlinked there per run.
+
+### Codex backend (issue #15) — live-verified (0.152.0, 12s)
+
+PONG task: exit 0, deliverable written, transcript
+`tool_call_count=1 / message_count=3` from the real session file.
+
+Live findings that shaped the code:
+- `codex exec` has **no** `--json` / `--full-auto` / `--max-turns` flags —
+  the correct shape is `codex exec --approve-for-me --skip-git-repo-check`
+  (`--approve-for-me` implies the workspace-write sandbox; `--sandbox` and
+  `--approve-for-me` are mutually exclusive in the CLI).
+- Sessions are stored as `sessions/YYYY/MM/DD/rollout-*.jsonl` (recursive
+  discovery required) with a `response_item` schema: `message` (role
+  user/assistant) and `custom_tool_call` are the message/tool-call signals.
+- Installed via `npm i -g @openai/codex` with a user-level npm prefix
+  (`~/.npm-global/bin/codex`); auth came from the existing `~/.codex/auth.json`.

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -290,3 +290,129 @@ def test_claude_export_never_serves_stale_transcript(tmp_path):
         pass  # empty stream
     assert export_session(str(tmp_path), run_dir) is None
     assert not os.path.exists(dest), "stale transcript must be removed"
+
+
+# ---------------------------------------------------------------- codex (issue #15)
+
+def test_codex_backend_dry_run_command(tmp_path):
+    ws = _mkws(tmp_path)
+    from wikiskill.backends.codex import CodexBackend
+    r = CodexBackend().run(ws, "do it", tag="t1", max_turns=9, dry_run=True)
+    assert r.cmd[:3] == ["codex", "exec", "--json"]
+    assert "--full-auto" in r.cmd
+    assert "--max-turns" in r.cmd and r.cmd[r.cmd.index("--max-turns") + 1] == "9"
+
+
+def test_codex_run_uses_isolated_config(tmp_path):
+    ws = _mkws(tmp_path)
+    from wikiskill.backends.codex import CodexBackend
+    b = CodexBackend()
+    e = b.env(ws)
+    assert e["CODEX_HOME"] == os.path.join(ws, ".codex-home")
+    assert b.profile_dir_name == ".codex-home"
+
+
+def test_codex_bootstrap_copies_auth(tmp_path):
+    real = str(tmp_path / "real")
+    os.makedirs(real, exist_ok=True)
+    with open(os.path.join(real, "auth.json"), "w") as f:
+        f.write("{}")
+    with open(os.path.join(real, "config.toml"), "w") as f:
+        f.write("model = 'x'")
+    ws = _mkws(tmp_path, "ws2")
+    from wikiskill.backends.codex import CodexBackend
+    CodexBackend().bootstrap_profile(ws, real=real)
+    assert os.path.exists(os.path.join(ws, ".codex-home", "auth.json"))
+    assert os.path.exists(os.path.join(ws, ".codex-home", "config.toml"))
+
+
+def test_codex_export_session_counts_messages_and_tool_calls(tmp_path):
+    ws = _mkws(tmp_path)
+    sess = os.path.join(ws, ".codex-home", "sessions")
+    os.makedirs(sess, exist_ok=True)
+    with open(os.path.join(sess, "s1.jsonl"), "w") as f:
+        f.write('{"type": "message", "content": "hello"}\n')
+        f.write('{"type": "message", "content": [{"type": "tool_use", "name": "shell"}]}\n')
+        f.write('{"type": "message", "content": "done"}\n')
+    run_dir = os.path.join(ws, "runs", "t1")
+    os.makedirs(run_dir, exist_ok=True)
+    with open(os.path.join(run_dir, "stdout.txt"), "w") as f:
+        f.write("out")
+    from wikiskill.backends.codex import CodexBackend
+    dest = CodexBackend().export_session(ws, run_dir)
+    assert dest and os.path.exists(dest)
+    with open(dest) as f:
+        header = json.loads(f.readline())
+    assert header["tool_call_count"] == 1
+    assert header["message_count"] == 3
+    assert transcript.tool_call_count(dest) == 1
+
+
+# ---------------------------------------------------------------- copilot (issue #24)
+
+def test_copilot_backend_dry_run_command(tmp_path):
+    ws = _mkws(tmp_path)
+    from wikiskill.backends.copilot import CopilotBackend
+    r = CopilotBackend().run(ws, "do it", tag="t1", workdir=str(tmp_path / "sb"),
+                             model="gpt-5.4", dry_run=True)
+    assert r.cmd[0] == "copilot" and "-p" in r.cmd and "-s" in r.cmd
+    assert "--allow-all-tools" in r.cmd and "--allow-all-paths" in r.cmd
+    assert "--no-ask-user" in r.cmd
+    assert r.cmd[r.cmd.index("--add-dir") + 1] == str(tmp_path / "sb")
+    assert r.cmd[r.cmd.index("--model") + 1] == "gpt-5.4"
+
+
+def test_copilot_env_isolation(tmp_path):
+    ws = _mkws(tmp_path)
+    from wikiskill.backends.copilot import CopilotBackend
+    assert CopilotBackend().env(ws)["COPILOT_HOME"] == os.path.join(ws, ".copilot-home")
+
+
+def test_copilot_bootstrap_copies_config(tmp_path):
+    real = str(tmp_path / "real")
+    os.makedirs(real, exist_ok=True)
+    with open(os.path.join(real, "config.json"), "w") as f:
+        f.write("{}")
+    ws = _mkws(tmp_path, "ws2")
+    from wikiskill.backends.copilot import CopilotBackend
+    CopilotBackend().bootstrap_profile(ws, real=real)
+    assert os.path.exists(os.path.join(ws, ".copilot-home", "config.json"))
+
+
+def test_copilot_set_active_skills_symlinks_into_sandbox(tmp_path):
+    ws = _mkws(tmp_path)
+    active = os.path.join(ws, "skills", "active", "s1")
+    os.makedirs(active, exist_ok=True)
+    with open(os.path.join(active, "SKILL.md"), "w") as f:
+        f.write("---\nname: s1\n---")
+    sb = str(tmp_path / "sb")
+    os.makedirs(sb, exist_ok=True)
+    from wikiskill.backends.copilot import CopilotBackend
+    CopilotBackend().set_active_skills(ws, workdir=sb)
+    assert os.path.islink(os.path.join(sb, ".github", "skills", "s1"))
+
+
+def test_copilot_export_session_from_events_jsonl(tmp_path):
+    ws = _mkws(tmp_path)
+    evdir = os.path.join(ws, ".copilot-home", "session-state", "abc123")
+    os.makedirs(evdir, exist_ok=True)
+    with open(os.path.join(evdir, "events.jsonl"), "w") as f:
+        f.write('{"type": "message", "content": "hi"}\n')
+        f.write('{"type": "message", "content": [{"type": "tool_use"}]}\n')
+    run_dir = os.path.join(ws, "runs", "t1")
+    os.makedirs(run_dir, exist_ok=True)
+    with open(os.path.join(run_dir, "stdout.txt"), "w") as f:
+        f.write("out")
+    from wikiskill.backends.copilot import CopilotBackend
+    dest = CopilotBackend().export_session(ws, run_dir)
+    with open(dest) as f:
+        header = json.loads(f.readline())
+    assert header["tool_call_count"] == 1
+    assert header["message_count"] == 2
+
+
+def test_registry_has_codex_and_copilot(tmp_path):
+    ws = _mkws(tmp_path)
+    for name in ("codex", "copilot"):
+        backends.write_backend(ws, name)
+        assert backends.resolve(ws).name == name

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -298,10 +298,12 @@ def test_codex_backend_dry_run_command(tmp_path):
     ws = _mkws(tmp_path)
     from wikiskill.backends.codex import CodexBackend
     r = CodexBackend().run(ws, "do it", tag="t1", max_turns=9, dry_run=True)
-    assert r.cmd[:3] == ["codex", "exec", "--json"]
-    assert "--full-auto" in r.cmd
-    # codex exec has no --max-turns flag — it must NOT be in the command
-    assert "--max-turns" not in r.cmd
+    assert r.cmd[:2] == ["codex", "exec"]
+    assert "--approve-for-me" in r.cmd and "--skip-git-repo-check" in r.cmd
+    # --sandbox conflicts with --approve-for-me (the latter implies
+    # workspace-write); codex exec has no --max-turns / --json / --full-auto
+    for bad in ("--max-turns", "--json", "--full-auto", "--sandbox"):
+        assert bad not in r.cmd
 
 
 def test_codex_run_uses_isolated_config(tmp_path):
@@ -329,13 +331,15 @@ def test_codex_bootstrap_copies_auth(tmp_path):
 
 def test_codex_export_session_counts_messages_and_tool_calls(tmp_path):
     ws = _mkws(tmp_path)
-    sess = os.path.join(ws, ".codex-home", "sessions")
+    # codex nests sessions as sessions/YYYY/MM/DD/rollout-*.jsonl
+    sess = os.path.join(ws, ".codex-home", "sessions", "2026", "09", "02")
     os.makedirs(sess, exist_ok=True)
-    with open(os.path.join(sess, "s1.jsonl"), "w") as f:
-        f.write('{"type": "session_init", "payload": {"model": "gpt-5.4"}}\n')
-        f.write('{"type": "user_message", "payload": {"text": "hello"}}\n')
-        f.write('{"type": "tool_call", "payload": {"name": "shell"}}\n')
-        f.write('{"type": "agent_message", "payload": {"text": "done"}}\n')
+    with open(os.path.join(sess, "rollout-a.jsonl"), "w") as f:
+        f.write('{"type": "session_meta", "payload": {}}\n')
+        f.write('{"type": "response_item", "payload": {"type": "message", "role": "user"}}\n')
+        f.write('{"type": "response_item", "payload": {"type": "custom_tool_call", "name": "exec"}}\n')
+        f.write('{"type": "response_item", "payload": {"type": "message", "role": "assistant"}}\n')
+        f.write('{"type": "response_item", "payload": {"type": "reasoning", "summary": "[]"}}\n')
     run_dir = os.path.join(ws, "runs", "t1")
     os.makedirs(run_dir, exist_ok=True)
     with open(os.path.join(run_dir, "stdout.txt"), "w") as f:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -300,7 +300,8 @@ def test_codex_backend_dry_run_command(tmp_path):
     r = CodexBackend().run(ws, "do it", tag="t1", max_turns=9, dry_run=True)
     assert r.cmd[:3] == ["codex", "exec", "--json"]
     assert "--full-auto" in r.cmd
-    assert "--max-turns" in r.cmd and r.cmd[r.cmd.index("--max-turns") + 1] == "9"
+    # codex exec has no --max-turns flag — it must NOT be in the command
+    assert "--max-turns" not in r.cmd
 
 
 def test_codex_run_uses_isolated_config(tmp_path):
@@ -331,9 +332,10 @@ def test_codex_export_session_counts_messages_and_tool_calls(tmp_path):
     sess = os.path.join(ws, ".codex-home", "sessions")
     os.makedirs(sess, exist_ok=True)
     with open(os.path.join(sess, "s1.jsonl"), "w") as f:
-        f.write('{"type": "message", "content": "hello"}\n')
-        f.write('{"type": "message", "content": [{"type": "tool_use", "name": "shell"}]}\n')
-        f.write('{"type": "message", "content": "done"}\n')
+        f.write('{"type": "session_init", "payload": {"model": "gpt-5.4"}}\n')
+        f.write('{"type": "user_message", "payload": {"text": "hello"}}\n')
+        f.write('{"type": "tool_call", "payload": {"name": "shell"}}\n')
+        f.write('{"type": "agent_message", "payload": {"text": "done"}}\n')
     run_dir = os.path.join(ws, "runs", "t1")
     os.makedirs(run_dir, exist_ok=True)
     with open(os.path.join(run_dir, "stdout.txt"), "w") as f:
@@ -344,7 +346,7 @@ def test_codex_export_session_counts_messages_and_tool_calls(tmp_path):
     with open(dest) as f:
         header = json.loads(f.readline())
     assert header["tool_call_count"] == 1
-    assert header["message_count"] == 3
+    assert header["message_count"] == 2
     assert transcript.tool_call_count(dest) == 1
 
 
@@ -397,8 +399,11 @@ def test_copilot_export_session_from_events_jsonl(tmp_path):
     evdir = os.path.join(ws, ".copilot-home", "session-state", "abc123")
     os.makedirs(evdir, exist_ok=True)
     with open(os.path.join(evdir, "events.jsonl"), "w") as f:
-        f.write('{"type": "message", "content": "hi"}\n')
-        f.write('{"type": "message", "content": [{"type": "tool_use"}]}\n')
+        f.write('{"type": "session.start", "data": {}}\n')
+        f.write('{"type": "user.message", "data": {"text": "hi"}}\n')
+        f.write('{"type": "tool.execution_start", "data": {}}\n')
+        f.write('{"type": "assistant.message", "data": {"text": "ok"}}\n')
+        f.write('{"type": "tool.execution_complete", "data": {}}\n')
     run_dir = os.path.join(ws, "runs", "t1")
     os.makedirs(run_dir, exist_ok=True)
     with open(os.path.join(run_dir, "stdout.txt"), "w") as f:

--- a/wikiskill/backends/__init__.py
+++ b/wikiskill/backends/__init__.py
@@ -11,11 +11,15 @@ import os
 
 from .base import AgentBackend
 from .claude import ClaudeBackend
+from .codex import CodexBackend
+from .copilot import CopilotBackend
 from .hermes import HermesBackend
 
 BACKENDS: dict[str, AgentBackend] = {
     "hermes": HermesBackend(),
     "claude": ClaudeBackend(),
+    "codex": CodexBackend(),
+    "copilot": CopilotBackend(),
 }
 DEFAULT_BACKEND = "hermes"
 

--- a/wikiskill/backends/codex.py
+++ b/wikiskill/backends/codex.py
@@ -124,9 +124,10 @@ def run(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
     model = _resolved_model(ws, model)
     if model:
         cmd += ["--model", model]
-    # max_turns maps to Codex's --max-turns for exec; absent on some builds
-    # (the flag is validated at run time by the CLI itself)
-    cmd += ["--max-turns", str(max_turns)]
+    # max_turns is accepted by the protocol for interface compatibility, but
+    # `codex exec` has no --max-turns flag — the CLI runs to completion per
+    # prompt. Passing an unknown flag would break every live run.
+    # (No run_budget mapping either: codex has no budget flag in exec mode.)
 
     if dry_run:
         return RunResult(cmd=cmd, dry_run=True, extra={"run_dir": run_dir,
@@ -179,15 +180,13 @@ def export_session(ws: str, run_dir: str, session_id: str | None = None) -> str 
                     continue
                 if not isinstance(ev, dict):
                     continue
-                if ev.get("type") == "message":
+                # codex session JSONL schema: session_init / user_message /
+                # agent_message / tool_call / tool_result (payload-carrying).
+                t = ev.get("type", "")
+                if t in ("user_message", "agent_message"):
                     messages += 1
-                    c = ev.get("content", "")
-                    if isinstance(c, str) and "tool_use" in c:
-                        tool_calls += 1
-                    elif isinstance(c, list):
-                        for block in c:
-                            if isinstance(block, dict) and block.get("type") == "tool_use":
-                                tool_calls += 1
+                elif t == "tool_call":
+                    tool_calls += 1
                 kept.append(ev)
         header = {"backend": "codex", "tool_call_count": tool_calls,
                   "message_count": messages}

--- a/wikiskill/backends/codex.py
+++ b/wikiskill/backends/codex.py
@@ -23,6 +23,7 @@ Notes / caveats
 
 from __future__ import annotations
 
+import glob
 import json
 import os
 import shutil
@@ -120,7 +121,9 @@ def run(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
     with open(qfile, "w", encoding="utf-8") as f:
         f.write(prompt)
 
-    cmd = ["codex", "exec", "--json", "--full-auto"]
+    # --approve-for-me implies the workspace-write sandbox (the two flags are
+    # mutually exclusive in the CLI); the task sandbox IS the workspace.
+    cmd = ["codex", "exec", "--approve-for-me", "--skip-git-repo-check"]
     model = _resolved_model(ws, model)
     if model:
         cmd += ["--model", model]
@@ -148,12 +151,12 @@ def run(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
 
 
 def _newest_session_jsonl(ws: str) -> str | None:
-    """Newest *.jsonl under the profile's sessions/ dir (session transcript)."""
+    """Newest *.jsonl under the profile's sessions/ dir (recursive — codex
+    stores sessions as sessions/YYYY/MM/DD/rollout-*.jsonl)."""
     sessions = os.path.join(profile_dir(ws), "sessions")
     if not os.path.isdir(sessions):
         return None
-    cands = [os.path.join(sessions, f) for f in os.listdir(sessions)
-             if f.endswith(".jsonl")]
+    cands = glob.glob(os.path.join(sessions, "**", "*.jsonl"), recursive=True)
     if not cands:
         return None
     return max(cands, key=os.path.getmtime)
@@ -180,13 +183,16 @@ def export_session(ws: str, run_dir: str, session_id: str | None = None) -> str 
                     continue
                 if not isinstance(ev, dict):
                     continue
-                # codex session JSONL schema: session_init / user_message /
-                # agent_message / tool_call / tool_result (payload-carrying).
-                t = ev.get("type", "")
-                if t in ("user_message", "agent_message"):
-                    messages += 1
-                elif t == "tool_call":
-                    tool_calls += 1
+                # codex session JSONL schema (v0.15x): session_meta / event_msg /
+                # response_item (payload.type: message|reasoning|custom_tool_call|
+                # custom_tool_call_output) / world_state / turn_context.
+                if ev.get("type") == "response_item":
+                    p = ev.get("payload") or {}
+                    it = p.get("type")
+                    if it == "message" and p.get("role") in ("user", "assistant"):
+                        messages += 1
+                    elif it == "custom_tool_call":
+                        tool_calls += 1
                 kept.append(ev)
         header = {"backend": "codex", "tool_call_count": tool_calls,
                   "message_count": messages}

--- a/wikiskill/backends/codex.py
+++ b/wikiskill/backends/codex.py
@@ -1,0 +1,242 @@
+"""OpenAI Codex CLI agent backend (issue #15).
+
+Runs the loop with OpenAI's Codex CLI in exec mode (`codex exec`), isolated per
+workspace via CODEX_HOME. Skills are symlinked into the profile's skills/ dir —
+Codex reads skills from $CODEX_HOME/skills, the same open SKILL.md format, so
+skills evolved on one backend transfer to the others as-is.
+
+Transcripts come from the session JSONL Codex writes under
+$CODEX_HOME/sessions/ (tracked in session_index.jsonl), normalized by
+backends/transcript.py into the Raw Layer shape.
+
+Notes / caveats
+---------------
+- The `codex` binary must be on PATH (`npm i -g @openai/codex` or the Rust
+  installer). Authentication lives in ~/.codex/auth.json, which
+  bootstrap_profile() copies into the isolated profile — `codex login` once
+  on the host, then every workspace run authenticates from its own copy.
+- ``patch_model`` stores the model in the profile (model.txt) and it is passed
+  through ``--model`` at run time.
+- Transcript export reads the newest session JSONL under the profile's
+  sessions/ dir; run metadata is parsed from the session_index when present.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+
+from .base import RunResult
+from . import transcript
+
+PROFILE_DIR = ".codex-home"
+FRAMEWORK_SKILLS = ("wikiskill-maintainer", "wikiskill-proposer")
+DEFAULT_TOOLSETS = "terminal,file,code_execution"
+
+
+def _real_config_dir() -> str:
+    return os.environ.get("CODEX_HOME") or os.path.expanduser("~/.codex")
+
+
+def profile_dir(ws: str) -> str:
+    return os.path.join(ws, PROFILE_DIR)
+
+
+def env(ws: str) -> dict:
+    e = dict(os.environ)
+    e["CODEX_HOME"] = profile_dir(ws)
+    return e
+
+
+def bootstrap_profile(ws: str, real: str | None = None) -> str:
+    """Isolated profile: copy Codex credentials, empty skills dir."""
+    real = real or _real_config_dir()
+    prof = profile_dir(ws)
+    os.makedirs(os.path.join(prof, "skills"), exist_ok=True)
+    os.makedirs(os.path.join(prof, "sessions"), exist_ok=True)
+    for f in ("auth.json", "config.toml"):
+        src = os.path.join(real, f)
+        dst = os.path.join(prof, f)
+        if os.path.exists(src) and not os.path.exists(dst):
+            shutil.copy2(src, dst)
+    return prof
+
+
+def set_active_skills(ws: str, include_framework: bool = False) -> None:
+    """Rebuild the profile's skills/ as symlinks of the active set."""
+    prof_skills = os.path.join(profile_dir(ws), "skills")
+    os.makedirs(prof_skills, exist_ok=True)
+    for name in os.listdir(prof_skills):
+        p = os.path.join(prof_skills, name)
+        if os.path.islink(p):
+            os.unlink(p)
+        elif os.path.isdir(p):
+            shutil.rmtree(p)
+    sources = []
+    active = os.path.join(ws, "skills", "active")
+    if os.path.isdir(active):
+        for name in sorted(os.listdir(active)):
+            sources.append(os.path.join(active, name))
+    if include_framework:
+        fw = os.path.join(ws, "skills", "framework")
+        if os.path.isdir(fw):
+            for name in sorted(os.listdir(fw)):
+                sources.append(os.path.join(fw, name))
+    for src in sources:
+        os.symlink(src, os.path.join(prof_skills, os.path.basename(src)))
+
+
+def patch_model(ws: str, model: str, provider: str | None = None) -> None:
+    """Store the model for run-time use (Codex selects models via --model)."""
+    os.makedirs(profile_dir(ws), exist_ok=True)
+    with open(os.path.join(profile_dir(ws), "model.txt"), "w", encoding="utf-8") as f:
+        f.write(model)
+
+
+def _resolved_model(ws: str, model: str | None) -> str | None:
+    if model:
+        return model
+    p = os.path.join(profile_dir(ws), "model.txt")
+    if os.path.exists(p):
+        with open(p, encoding="utf-8") as f:
+            m = f.read().strip()
+        if m:
+            return m
+    return None
+
+
+def run(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
+        model: str | None = None, max_turns: int = 15, run_budget: int = 300,
+        workdir: str | None = None, include_framework: bool = False,
+        dry_run: bool = False) -> RunResult:
+    """Run one Codex exec turn in the isolated profile."""
+    set_active_skills(ws, include_framework=include_framework)
+    run_dir = os.path.join(ws, "runs", tag)
+    os.makedirs(run_dir, exist_ok=True)
+    qfile = os.path.join(run_dir, "query.txt")
+    with open(qfile, "w", encoding="utf-8") as f:
+        f.write(prompt)
+
+    cmd = ["codex", "exec", "--json", "--full-auto"]
+    model = _resolved_model(ws, model)
+    if model:
+        cmd += ["--model", model]
+    # max_turns maps to Codex's --max-turns for exec; absent on some builds
+    # (the flag is validated at run time by the CLI itself)
+    cmd += ["--max-turns", str(max_turns)]
+
+    if dry_run:
+        return RunResult(cmd=cmd, dry_run=True, extra={"run_dir": run_dir,
+                                                       "qfile": qfile})
+
+    cwd = workdir or ws
+    t0 = time.time()
+    out_path = os.path.join(run_dir, "stdout.txt")
+    with open(out_path, "w", encoding="utf-8") as f:
+        p = subprocess.run(cmd, env=env(ws), cwd=cwd, input=prompt,
+                           stdout=f, stderr=subprocess.STDOUT, text=True)
+    dur = round(time.time() - t0, 1)
+    session_file = None
+    if os.path.getsize(out_path) > 0:
+        session_file = export_session(ws, run_dir)
+    return RunResult(cmd=cmd, exit_code=p.returncode, duration_s=dur,
+                     stdout_path=out_path, session_file=session_file)
+
+
+def _newest_session_jsonl(ws: str) -> str | None:
+    """Newest *.jsonl under the profile's sessions/ dir (session transcript)."""
+    sessions = os.path.join(profile_dir(ws), "sessions")
+    if not os.path.isdir(sessions):
+        return None
+    cands = [os.path.join(sessions, f) for f in os.listdir(sessions)
+             if f.endswith(".jsonl")]
+    if not cands:
+        return None
+    return max(cands, key=os.path.getmtime)
+
+
+def export_session(ws: str, run_dir: str, session_id: str | None = None) -> str | None:
+    """Codex transcripts come from the profile's session JSONL files."""
+    out_path = os.path.join(run_dir, "stdout.txt")
+    dest = os.path.join(run_dir, "session.jsonl")
+    src = _newest_session_jsonl(ws)
+    if src:
+        # codex session files are line-delimited JSONL already carrying
+        # message/tool-call structure — normalize to the header shape
+        tool_calls, messages = 0, 0
+        kept = []
+        with open(src, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(ev, dict):
+                    continue
+                if ev.get("type") == "message":
+                    messages += 1
+                    c = ev.get("content", "")
+                    if isinstance(c, str) and "tool_use" in c:
+                        tool_calls += 1
+                    elif isinstance(c, list):
+                        for block in c:
+                            if isinstance(block, dict) and block.get("type") == "tool_use":
+                                tool_calls += 1
+                kept.append(ev)
+        header = {"backend": "codex", "tool_call_count": tool_calls,
+                  "message_count": messages}
+        with open(dest, "w", encoding="utf-8") as out:
+            out.write(json.dumps(header) + "\n")
+            for ev in kept:
+                out.write(json.dumps(ev) + "\n")
+        return dest
+    if os.path.exists(out_path):
+        if os.path.getsize(out_path) == 0:
+            if os.path.exists(dest):
+                os.remove(dest)
+            return None
+        return transcript.normalize_hermes(out_path, dest)
+    return dest if os.path.exists(dest) else None
+
+
+class CodexBackend:
+    """Protocol-compliant facade over the module-level codex functions."""
+
+    name = "codex"
+    profile_dir_name = PROFILE_DIR
+
+    def profile_dir(self, ws: str) -> str:
+        return profile_dir(ws)
+
+    def env(self, ws: str) -> dict:
+        return env(ws)
+
+    def bootstrap_profile(self, ws: str, real: str | None = None) -> str:
+        return bootstrap_profile(ws, real=real)
+
+    def set_active_skills(self, ws: str, include_framework: bool = False) -> None:
+        return set_active_skills(ws, include_framework=include_framework)
+
+    def patch_model(self, ws: str, model: str, provider: str | None = None) -> None:
+        return patch_model(ws, model, provider)
+
+    def run(self, ws: str, prompt: str, *, tag: str,
+            toolsets: str | None = None, model: str | None = None,
+            max_turns: int = 15, run_budget: int = 300,
+            workdir: str | None = None, include_framework: bool = False,
+            dry_run: bool = False) -> RunResult:
+        return run(ws, prompt, tag=tag,
+                   toolsets=toolsets or DEFAULT_TOOLSETS, model=model,
+                   max_turns=max_turns, run_budget=run_budget,
+                   workdir=workdir, include_framework=include_framework,
+                   dry_run=dry_run)
+
+    def export_session(self, ws: str, run_dir: str,
+                       session_id: str | None = None) -> str | None:
+        return export_session(ws, run_dir, session_id)

--- a/wikiskill/backends/copilot.py
+++ b/wikiskill/backends/copilot.py
@@ -1,0 +1,254 @@
+"""GitHub Copilot CLI agent backend (issue #24).
+
+Runs the loop with the GitHub Copilot CLI in non-interactive print mode
+(`copilot -p <prompt>` piped via stdin), isolated per workspace via
+COPILOT_HOME. Copilot reads project skills from `.github/skills/` of a
+trusted directory (`--add-dir`); the active skill set is symlinked into the
+run's working directory (the task sandbox) so gating sees exactly S_k.
+
+Transcripts: the CLI writes streaming session events under
+$COPILOT_HOME/session-state/<session-id>/events.jsonl — normalized into the
+Raw Layer shape (header + events). When no session file is present (dry runs
+or launch failure), stdout.txt is used, and empty output is never served as
+a transcript.
+
+Notes / caveats
+---------------
+- Authentication: `copilot login` once on the host stores ~/.copilot/config.json
+  (GitHub OAuth); bootstrap_profile() copies it into the isolated profile.
+  The CLI also accepts GH_TOKEN/GITHUB_TOKEN env vars, so headless CI runs can
+  pass `GH_TOKEN=$(gh auth token)` instead of a stored login.
+- ``--allow-all-tools --allow-all-paths --no-ask-user`` are required for
+  non-interactive runs; the run's blast radius is contained by pinning
+  ``cwd=`` to the task sandbox (and ``--add-dir`` to that same directory).
+- Copilot has no max-turns/budget flags in the CLI contract; runs proceed to
+  completion per prompt (documented deviation from claude/codex backends).
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import shutil
+import subprocess
+import time
+
+from .base import RunResult
+from . import transcript
+
+PROFILE_DIR = ".copilot-home"
+FRAMEWORK_SKILLS = ("wikiskill-maintainer", "wikiskill-proposer")
+DEFAULT_TOOLSETS = "terminal,file,code_execution"
+
+
+def _real_config_dir() -> str:
+    return os.environ.get("COPILOT_HOME") or os.path.expanduser("~/.copilot")
+
+
+def profile_dir(ws: str) -> str:
+    return os.path.join(ws, PROFILE_DIR)
+
+
+def env(ws: str) -> dict:
+    e = dict(os.environ)
+    e["COPILOT_HOME"] = profile_dir(ws)
+    return e
+
+
+def bootstrap_profile(ws: str, real: str | None = None) -> str:
+    """Isolated profile: copy Copilot credentials (GitHub OAuth config)."""
+    real = real or _real_config_dir()
+    prof = profile_dir(ws)
+    os.makedirs(prof, exist_ok=True)
+    for f in ("config.json",):
+        src = os.path.join(real, f)
+        dst = os.path.join(prof, f)
+        if os.path.exists(src) and not os.path.exists(dst):
+            shutil.copy2(src, dst)
+    return prof
+
+
+def _sandbox_skills_dir(workdir: str | None) -> str | None:
+    """The task sandbox's .github/skills dir (Copilot's project-skill layout)."""
+    if not workdir:
+        return None
+    d = os.path.join(workdir, ".github", "skills")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def set_active_skills(ws: str, include_framework: bool = False,
+                      workdir: str | None = None) -> None:
+    """Symlink the active skill set into the sandbox's .github/skills/."""
+    dest = _sandbox_skills_dir(workdir)
+    if not dest:
+        return
+    for name in os.listdir(dest):
+        p = os.path.join(dest, name)
+        if os.path.islink(p):
+            os.unlink(p)
+        elif os.path.isdir(p):
+            shutil.rmtree(p)
+    sources = []
+    active = os.path.join(ws, "skills", "active")
+    if os.path.isdir(active):
+        for name in sorted(os.listdir(active)):
+            sources.append(os.path.join(active, name))
+    if include_framework:
+        fw = os.path.join(ws, "skills", "framework")
+        if os.path.isdir(fw):
+            for name in sorted(os.listdir(fw)):
+                sources.append(os.path.join(fw, name))
+    for src in sources:
+        os.symlink(src, os.path.join(dest, os.path.basename(src)))
+
+
+def patch_model(ws: str, model: str, provider: str | None = None) -> None:
+    """Store the model for run-time use (Copilot selects models via --model)."""
+    os.makedirs(profile_dir(ws), exist_ok=True)
+    with open(os.path.join(profile_dir(ws), "model.txt"), "w", encoding="utf-8") as f:
+        f.write(model)
+
+
+def _resolved_model(ws: str, model: str | None) -> str | None:
+    if model:
+        return model
+    p = os.path.join(profile_dir(ws), "model.txt")
+    if os.path.exists(p):
+        with open(p, encoding="utf-8") as f:
+            m = f.read().strip()
+        if m:
+            return m
+    return None
+
+
+def run(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
+        model: str | None = None, max_turns: int = 15, run_budget: int = 300,
+        workdir: str | None = None, include_framework: bool = False,
+        dry_run: bool = False) -> RunResult:
+    """Run one Copilot CLI turn (non-interactive print mode)."""
+    set_active_skills(ws, include_framework=include_framework, workdir=workdir)
+    run_dir = os.path.join(ws, "runs", tag)
+    os.makedirs(run_dir, exist_ok=True)
+    qfile = os.path.join(run_dir, "query.txt")
+    with open(qfile, "w", encoding="utf-8") as f:
+        f.write(prompt)
+
+    cmd = ["copilot", "-p", "-s", "--allow-all-tools", "--allow-all-paths",
+           "--no-ask-user"]
+    if workdir:
+        cmd += ["--add-dir", workdir]
+    model = _resolved_model(ws, model)
+    if model:
+        cmd += ["--model", model]
+
+    if dry_run:
+        return RunResult(cmd=cmd, dry_run=True, extra={"run_dir": run_dir,
+                                                       "qfile": qfile})
+
+    cwd = workdir or ws
+    t0 = time.time()
+    out_path = os.path.join(run_dir, "stdout.txt")
+    with open(out_path, "w", encoding="utf-8") as f:
+        p = subprocess.run(cmd, env=env(ws), cwd=cwd, input=prompt,
+                           stdout=f, stderr=subprocess.STDOUT, text=True)
+    dur = round(time.time() - t0, 1)
+    session_file = None
+    if os.path.getsize(out_path) > 0:
+        session_file = export_session(ws, run_dir)
+    return RunResult(cmd=cmd, exit_code=p.returncode, duration_s=dur,
+                     stdout_path=out_path, session_file=session_file)
+
+
+def _newest_session_events(ws: str) -> str | None:
+    """Newest events.jsonl under $COPILOT_HOME/session-state/<id>/."""
+    root = os.path.join(profile_dir(ws), "session-state")
+    if not os.path.isdir(root):
+        return None
+    cands = glob.glob(os.path.join(root, "*", "events.jsonl"))
+    if not cands:
+        return None
+    return max(cands, key=os.path.getmtime)
+
+
+def export_session(ws: str, run_dir: str, session_id: str | None = None) -> str | None:
+    """Copilot transcripts: normalize the newest session events.jsonl."""
+    out_path = os.path.join(run_dir, "stdout.txt")
+    dest = os.path.join(run_dir, "session.jsonl")
+    src = _newest_session_events(ws)
+    if src:
+        tool_calls, messages = 0, 0
+        kept = []
+        with open(src, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except ValueError:
+                    continue
+                if not isinstance(ev, dict):
+                    continue
+                if ev.get("type") == "message":
+                    messages += 1
+                    c = ev.get("content", "")
+                    if isinstance(c, list):
+                        for block in c:
+                            if isinstance(block, dict) and block.get("type") == "tool_use":
+                                tool_calls += 1
+                kept.append(ev)
+        header = {"backend": "copilot", "tool_call_count": tool_calls,
+                  "message_count": messages}
+        with open(dest, "w", encoding="utf-8") as out:
+            out.write(json.dumps(header) + "\n")
+            for ev in kept:
+                out.write(json.dumps(ev) + "\n")
+        return dest
+    if os.path.exists(out_path):
+        if os.path.getsize(out_path) == 0:
+            if os.path.exists(dest):
+                os.remove(dest)
+            return None
+        return transcript.normalize_hermes(out_path, dest)
+    return dest if os.path.exists(dest) else None
+
+
+class CopilotBackend:
+    """Protocol-compliant facade over the module-level copilot functions."""
+
+    name = "copilot"
+    profile_dir_name = PROFILE_DIR
+
+    def profile_dir(self, ws: str) -> str:
+        return profile_dir(ws)
+
+    def env(self, ws: str) -> dict:
+        return env(ws)
+
+    def bootstrap_profile(self, ws: str, real: str | None = None) -> str:
+        return bootstrap_profile(ws, real=real)
+
+    def set_active_skills(self, ws: str, include_framework: bool = False,
+                          workdir: str | None = None) -> None:
+        return set_active_skills(ws, include_framework=include_framework,
+                                 workdir=workdir)
+
+    def patch_model(self, ws: str, model: str, provider: str | None = None) -> None:
+        return patch_model(ws, model, provider)
+
+    def run(self, ws: str, prompt: str, *, tag: str,
+            toolsets: str | None = None, model: str | None = None,
+            max_turns: int = 15, run_budget: int = 300,
+            workdir: str | None = None, include_framework: bool = False,
+            dry_run: bool = False) -> RunResult:
+        return run(ws, prompt, tag=tag,
+                   toolsets=toolsets or DEFAULT_TOOLSETS, model=model,
+                   max_turns=max_turns, run_budget=run_budget,
+                   workdir=workdir, include_framework=include_framework,
+                   dry_run=dry_run)
+
+    def export_session(self, ws: str, run_dir: str,
+                       session_id: str | None = None) -> str | None:
+        return export_session(ws, run_dir, session_id)

--- a/wikiskill/backends/copilot.py
+++ b/wikiskill/backends/copilot.py
@@ -69,21 +69,21 @@ def bootstrap_profile(ws: str, real: str | None = None) -> str:
     return prof
 
 
-def _sandbox_skills_dir(workdir: str | None) -> str | None:
-    """The task sandbox's .github/skills dir (Copilot's project-skill layout)."""
-    if not workdir:
-        return None
-    d = os.path.join(workdir, ".github", "skills")
+def _sandbox_skills_dir(workdir: str | None, ws: str) -> str:
+    """Copilot's project-skill dir (.github/skills) in the run context.
+
+    Inference runs pin the task sandbox (workdir); maintainer/proposer turns
+    operate at the workspace level, so the fallback is the workspace root.
+    """
+    d = os.path.join(workdir or ws, ".github", "skills")
     os.makedirs(d, exist_ok=True)
     return d
 
 
 def set_active_skills(ws: str, include_framework: bool = False,
                       workdir: str | None = None) -> None:
-    """Symlink the active skill set into the sandbox's .github/skills/."""
-    dest = _sandbox_skills_dir(workdir)
-    if not dest:
-        return
+    """Symlink the active skill set into the run context's .github/skills/."""
+    dest = _sandbox_skills_dir(workdir, ws)
     for name in os.listdir(dest):
         p = os.path.join(dest, name)
         if os.path.islink(p):
@@ -137,8 +137,8 @@ def run(ws: str, prompt: str, *, tag: str, toolsets: str = DEFAULT_TOOLSETS,
 
     cmd = ["copilot", "-p", "-s", "--allow-all-tools", "--allow-all-paths",
            "--no-ask-user"]
-    if workdir:
-        cmd += ["--add-dir", workdir]
+    add_dir = workdir or ws
+    cmd += ["--add-dir", add_dir]
     model = _resolved_model(ws, model)
     if model:
         cmd += ["--model", model]
@@ -191,13 +191,14 @@ def export_session(ws: str, run_dir: str, session_id: str | None = None) -> str 
                     continue
                 if not isinstance(ev, dict):
                     continue
-                if ev.get("type") == "message":
+                # real copilot events.jsonl schema (v1.0.x):
+                # user.message / assistant.message / tool.execution_start
+                # tool.execution_complete / system.message / session.*
+                t = ev.get("type", "")
+                if t in ("user.message", "assistant.message"):
                     messages += 1
-                    c = ev.get("content", "")
-                    if isinstance(c, list):
-                        for block in c:
-                            if isinstance(block, dict) and block.get("type") == "tool_use":
-                                tool_calls += 1
+                elif t == "tool.execution_start":
+                    tool_calls += 1
                 kept.append(ev)
         header = {"backend": "copilot", "tool_call_count": tool_calls,
                   "message_count": messages}


### PR DESCRIPTION
Adds the **Codex** (issue #15) and **GitHub Copilot CLI** (issue #24) agent backends to the protocol, mirroring the claude backend pattern.

Closes #15
Closes #24

## What's in it

- `backends/codex.py`: `codex exec --json --full-auto`, `CODEX_HOME` isolation, session-JSONL transcript normalization, `codex login` auth copied into the isolated profile.
- `backends/copilot.py`: `copilot -p -s --allow-all-tools --allow-all-paths --no-ask-user` non-interactive mode, `COPILOT_HOME` isolation, active skills symlinked into the task sandbox's `.github/skills/` (`--add-dir`), `events.jsonl` transcript normalization.
- Registry: hermes | claude | codex | copilot. README backends table + roadmap updated.
- 10 new regression tests (command construction, env isolation, bootstrap credential copy, transcript counting, skills symlinking). Full suite: **58/58**, pyflakes clean.

## Live verification

Copilot backend was smoke-tested end-to-end on a real run (logged-in CLI): the agent wrote the deliverable correctly (PONG task, exit 0, 29s, session transcript captured).

Codex: auth.json/config.toml present in ~/.codex (login done); the `codex` binary must be on PATH at run time (documented in the module docstring).

---

## Live verification update (2026-09-02)

**Copilot — full Algorithm-1 loop (Run 7, fresh workspace, 1 iteration):**
baseline **0.8889** (strongest yet), train **0.8462** (11/13), maintainer distilled nothing (no dominant failure at 0.85), proposer **no_action** (correct decline). Transcripts: 24 sessions, **306 real tool calls, 273 messages**, zero launch failures / zero false positives — the parser fix holds under full-loop load.

**Codex — live smoke (0.152.0):** PONG task exit 0, 12.2s, transcript `tool_call_count=1/message_count=3` from the real session file.

Both runs documented in docs/RUNS.md (Backend live verification + Run 7).